### PR TITLE
revamp: use JAVA_HOME first, others all "fallback" now

### DIFF
--- a/repositories/java-version-repository/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionUtils.kt
+++ b/repositories/java-version-repository/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionUtils.kt
@@ -48,9 +48,14 @@ suspend fun parseVersionInfo(path: String): JavaVersionInfo? {
 fun locateAllJavaVersions(): List<File> {
     val versionFolders = mutableListOf<File>()
 
+    val homePathSplit = System.getenv("JAVA_HOME").split(File.separator)
+    val homePath = homePathSplit.subList(0, homePathSplit.size - 2).joinToString(File.separator)
+
     when (getOperatingSystemType()) {
+
         OSType.WINDOWS -> {
-            mutableListOf<String>(
+            mutableListOf(
+               homePath,
                 "\\Program Files\\Java",
                 "\\Program Files (x86)\\Java"
             ).filter {
@@ -64,7 +69,8 @@ fun locateAllJavaVersions(): List<File> {
                 .forEach { versionFolders.addAll(it.listFiles()!!.toList()) }
         }
         OSType.LINUX -> {
-            mutableListOf<String>(
+            mutableListOf(
+                homePath,
                 "/usr/lib/jvm",
                 "/usr/lib64/jvm"
             ).filter { it.isNotEmpty() }.map { File(it) }.filter { it.exists() }.filter { it.isDirectory }


### PR DESCRIPTION
The cloud will now use the JAVA_HOME environment variable to possibly track down installed java versions.
Next, it'll go back exactly one folder which usually is the location where seperate versions are installed. This path is now used to detect all java versions in that folder. The corresponding file seperator for each OS is being used (`java.io.File#seperator`) to provide support for the most operating systems.

The example/output of the path looks like the following:
1. JAVA_HOME => `C:\Program Files\Zulu\zulu-17\`
2. Go back 1 folder => `C:\Program Files\Zulu\`

And this is exactly the location where the java versions are installed. This may work for the most users as they won't relocate each java version seperately.