### PR TITLE
player executor api functions

### DIFF
--- a/apis/base-api/build.gradle.kts
+++ b/apis/base-api/build.gradle.kts
@@ -9,4 +9,5 @@ val publishToRepository by extra(true)
 dependencies {
     compileOnly(project(":utils"))
     compileOnly(project(":logging"))
+    compileOnly(BuildDependencies.KYORI_ADVENTURE_API)
 }

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/player/ICloudPlayerExecutor.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/player/ICloudPlayerExecutor.kt
@@ -1,0 +1,51 @@
+package dev.redicloud.api.player
+
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.server.ICloudServer
+import net.kyori.adventure.bossbar.BossBar
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.resource.ResourcePackRequest
+import net.kyori.adventure.sound.Sound
+import java.util.UUID
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.title.Title
+
+interface ICloudPlayerExecutor {
+
+    suspend fun sendMessage(uniqueId: UUID, component: Component)
+    suspend fun sendMessage(cloudPlayer: ICloudPlayer, component: Component)
+
+    suspend fun showBossBar(uniqueId: UUID, bossBar: BossBar)
+    suspend fun showBossBar(cloudPlayer: ICloudPlayer, bossBar: BossBar)
+
+    suspend fun hideBossBar(uniqueId: UUID, bossBar: BossBar)
+    suspend fun hideBossBar(cloudPlayer: ICloudPlayer, bossBar: BossBar)
+
+    suspend fun playSound(uniqueId: UUID, sound: Sound)
+    suspend fun playSound(cloudPlayer: ICloudPlayer, sound: Sound)
+
+    suspend fun stopSound(uniqueId: UUID, sound: Sound)
+    suspend fun stopSound(cloudPlayer: ICloudPlayer, sound: Sound)
+
+    suspend fun showTitle(uniqueId: UUID, title: Title)
+    suspend fun showTitle(cloudPlayer: ICloudPlayer, title: Title)
+
+    suspend fun showBook(uniqueId: UUID, book: Book)
+    suspend fun showBook(cloudPlayer: ICloudPlayer, book: Book)
+
+    suspend fun sendPlayerListHeaderAndFooter(uniqueId: UUID, header: Component, footer: Component)
+    suspend fun sendPlayerListHeaderAndFooter(cloudPlayer: ICloudPlayer, header: Component, footer: Component)
+
+    suspend fun sendResourcePacks(uniqueId: UUID, resourcePackRequest: ResourcePackRequest)
+    suspend fun sendResourcePacks(cloudPlayer: ICloudPlayer, resourcePackRequest: ResourcePackRequest)
+
+    suspend fun connect(uniqueId: UUID, serviceId: ServiceId)
+    suspend fun connect(uniqueId: UUID, serverName: String)
+    suspend fun connect(cloudPlayer: ICloudPlayer, serverName: String)
+    suspend fun connect(cloudPlayer: ICloudPlayer, serviceId: ServiceId)
+    suspend fun connect(cloudPlayer: ICloudPlayer, server: ICloudServer)
+
+    suspend fun kick(uniqueId: UUID, reason: Component)
+    suspend fun kick(cloudPlayer: ICloudPlayer, reason: Component)
+
+}

--- a/buildSrc/src/main/kotlin/BuildDependencies.kt
+++ b/buildSrc/src/main/kotlin/BuildDependencies.kt
@@ -37,6 +37,11 @@ object BuildDependencies {
     const val DOCKER_TEST_CONTAINERS = "org.testcontainers:testcontainers:1.19.7"
     const val BCPROV = "org.bouncycastle:bcprov-jdk15on:1.70"
     const val BCPKIX = "org.bouncycastle:bcpkix-jdk15on:1.70"
+
+    const val KYORI_ADVENTURE_API = "net.kyori:adventure-api:4.17.0"
+    const val KYORI_ADVENTURE_BUKKIT = "net.kyori:adventure-platform-bukkit:4.3.3"
+    const val KYORI_ADVENTURE_BUNGEECORD = "net.kyori:adventure-platform-bungeecord:4.3.3"
+    const val KYORI_ADVENTURE_SERIALIZER_GSON = "net.kyori:adventure-text-serializer-gson:4.17.0"
 }
 
 fun String.withVersion(version: String): String {

--- a/buildSrc/src/main/kotlin/BuildDependencies.kt
+++ b/buildSrc/src/main/kotlin/BuildDependencies.kt
@@ -1,5 +1,5 @@
 object BuildDependencies {
-    const val CLOUD_VERSION = "2.3.7-SNAPSHOT"
+    const val CLOUD_VERSION = "2.4.0-SNAPSHOT"
     const val CLOUD_LIBLOADER_VERSION = "1.7.0"
     const val CLOUD_LIBLOADER_BOOTSTRAP = "dev.redicloud.libloader:libloader-bootstrap:1.7.0"
 

--- a/connectors/bukkit-connector/build.gradle.kts
+++ b/connectors/bukkit-connector/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
 
     compileOnly(BuildDependencies.SPIGOT_API)
     shade(project(":connectors:bukkit-legacy"))
+
+    compileOnly(BuildDependencies.KYORI_ADVENTURE_API)
+    compileOnly(BuildDependencies.KYORI_ADVENTURE_BUKKIT)
 }
 
 val shadowModJar by tasks.creating(ShadowJar::class) {

--- a/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/BukkitConnector.kt
+++ b/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/BukkitConnector.kt
@@ -1,11 +1,14 @@
 package dev.redicloud.connector.bukkit
 
 import dev.redicloud.api.provider.IServerPlayerProvider
+import dev.redicloud.connector.bukkit.player.BukkitPlayerExecutor
 import dev.redicloud.connector.bukkit.provider.BukkitScreenProvider
 import dev.redicloud.connector.bukkit.provider.BukkitServerPlayerProvider
+import dev.redicloud.service.base.player.BasePlayerExecutor
 import dev.redicloud.service.minecraft.MinecraftServerService
 import dev.redicloud.service.minecraft.provider.AbstractScreenProvider
 import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.platform.bukkit.BukkitAudiences
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
@@ -14,6 +17,7 @@ class BukkitConnector(val plugin: JavaPlugin) : MinecraftServerService<JavaPlugi
     internal var bukkitShuttingDown = false
     override var playerProvider: IServerPlayerProvider = BukkitServerPlayerProvider()
     override val screenProvider: AbstractScreenProvider = BukkitScreenProvider(this.packetManager, this.plugin)
+    override val playerExecutor: BasePlayerExecutor = BukkitPlayerExecutor(this.plugin, this.playerRepository, this.serverRepository, this.packetManager, this.serviceId)
 
     init {
         initApi()

--- a/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/player/BukkitPlayerExecutor.kt
+++ b/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/player/BukkitPlayerExecutor.kt
@@ -1,0 +1,42 @@
+package dev.redicloud.connector.bukkit.player
+
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.player.ICloudPlayer
+import dev.redicloud.api.player.ICloudPlayerRepository
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.server.ICloudServer
+import dev.redicloud.api.service.server.ICloudServerRepository
+import dev.redicloud.service.base.player.BasePlayerExecutor
+import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.platform.bukkit.BukkitAudiences
+import net.kyori.adventure.text.Component
+import org.bukkit.plugin.java.JavaPlugin
+
+class BukkitPlayerExecutor(
+    private val plugin: JavaPlugin,
+    playerRepository: ICloudPlayerRepository,
+    serverRepository: ICloudServerRepository,
+    packetManager: IPacketManager,
+    thisServiceId: ServiceId
+) : BasePlayerExecutor(playerRepository, serverRepository, packetManager, thisServiceId) {
+
+    private var _audience: BukkitAudiences? = null
+
+    override fun audience(player: ICloudPlayer): Audience {
+        if (_audience == null) {
+            _audience = BukkitAudiences.create(plugin)
+        }
+        return _audience!!.player(player.uniqueId)
+    }
+
+    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        runBlocking { this@BukkitPlayerExecutor.connect(cloudPlayer, server) }
+    }
+
+    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        runBlocking { this@BukkitPlayerExecutor.kick(cloudPlayer, reason) }
+    }
+
+
+}

--- a/connectors/bukkit-connector/src/main/resources/plugin.yml
+++ b/connectors/bukkit-connector/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: redicloud-connector
-version: 2.3.7-SNAPSHOT
+version: 2.4.0-SNAPSHOT
 main: dev.redicloud.connector.bukkit.bootstrap.BukkitConnectorBootstrap
 author: RediCloud
 description: RediCloud Connector Bukkit

--- a/connectors/bukkit-legacy/build.gradle.kts
+++ b/connectors/bukkit-legacy/build.gradle.kts
@@ -15,4 +15,6 @@ dependencies {
     shade(BuildDependencies.NETTY_COMMON)
     shade(BuildDependencies.LOGBACK_CORE.withVersion("1.3.14"))
     shade(BuildDependencies.LOGBACK_CLASSIC.withVersion("1.3.14"))
+    dependency(BuildDependencies.KYORI_ADVENTURE_API)
+    dependency(BuildDependencies.KYORI_ADVENTURE_BUKKIT)
 }

--- a/connectors/bungeecord-connector/build.gradle.kts
+++ b/connectors/bungeecord-connector/build.gradle.kts
@@ -34,4 +34,6 @@ dependencies {
     shade(BuildDependencies.CLOUD_LIBLOADER_BOOTSTRAP)
 
     compileOnly(BuildDependencies.BUNGEECORD_API)
+    dependency(BuildDependencies.KYORI_ADVENTURE_API)
+    dependency(BuildDependencies.KYORI_ADVENTURE_BUNGEECORD)
 }

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
@@ -8,7 +8,10 @@ import dev.redicloud.repository.server.CloudMinecraftServer
 import dev.redicloud.service.minecraft.ProxyServerService
 import dev.redicloud.service.minecraft.provider.AbstractScreenProvider
 import dev.redicloud.api.service.ServiceId
+import dev.redicloud.connector.bungeecord.player.BungeeCordPlayerExecutor
+import dev.redicloud.service.base.player.BasePlayerExecutor
 import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.platform.bungeecord.BungeeAudiences
 import net.md_5.bungee.api.ProxyServer
 import net.md_5.bungee.api.config.ServerInfo
 import net.md_5.bungee.api.plugin.Listener
@@ -22,6 +25,8 @@ class BungeeCordConnector(
     internal var bungeecordShuttingDown: Boolean = false
     override var playerProvider: IServerPlayerProvider = BungeeCordServerPlayerProvider()
     override val screenProvider: AbstractScreenProvider = BungeeCordScreenProvider(this.packetManager)
+    override val playerExecutor: BasePlayerExecutor = BungeeCordPlayerExecutor(this.plugin, this.playerRepository, this.serverRepository, this.packetManager, this.serviceId)
+
 
     init {
         initApi()

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/player/BungeeCordPlayerExecutor.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/player/BungeeCordPlayerExecutor.kt
@@ -1,0 +1,56 @@
+package dev.redicloud.connector.bungeecord.player
+
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.player.ICloudPlayer
+import dev.redicloud.api.player.ICloudPlayerRepository
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.server.ICloudServer
+import dev.redicloud.api.service.server.ICloudServerRepository
+import dev.redicloud.service.base.player.BasePlayerExecutor
+import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.platform.bungeecord.BungeeAudiences
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.bungeecord.BungeeComponentSerializer
+import net.md_5.bungee.api.ProxyServer
+import net.md_5.bungee.api.plugin.Plugin
+
+class BungeeCordPlayerExecutor(
+    private val plugin: Plugin,
+    playerRepository: ICloudPlayerRepository,
+    serverRepository: ICloudServerRepository,
+    packetManager: IPacketManager,
+    thisServiceId: ServiceId
+) : BasePlayerExecutor(playerRepository, serverRepository, packetManager, thisServiceId) {
+
+    private var audiences: BungeeAudiences? = null
+
+    override fun audience(player: ICloudPlayer): Audience {
+        if (audiences == null) {
+            audiences = BungeeAudiences.create(plugin)
+        }
+        return audiences!!.player(player.uniqueId)
+    }
+
+    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        val player = ProxyServer.getInstance().getPlayer(cloudPlayer.uniqueId)
+        if (player == null || !player.isConnected) {
+            runBlocking { this@BungeeCordPlayerExecutor.connect(cloudPlayer, server) }
+            return
+        }
+        val serverInfo = ProxyServer.getInstance().getServerInfo(server.name) ?: return
+        player.connect(serverInfo)
+    }
+
+    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        val player = ProxyServer.getInstance().getPlayer(cloudPlayer.uniqueId)
+        if (player == null || !player.isConnected) {
+            runBlocking { this@BungeeCordPlayerExecutor.executeKick(cloudPlayer, reason) }
+            return
+        }
+        val components = BungeeComponentSerializer.get().serialize(reason)
+        player.disconnect(*components)
+    }
+
+
+}

--- a/connectors/bungeecord-connector/src/main/resources/bungee.yml
+++ b/connectors/bungeecord-connector/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: redicloud-connector
-version: 2.3.7-SNAPSHOT
+version: 2.4.0-SNAPSHOT
 url: https://redicloud.dev
 author: RediCloud
 main: dev.redicloud.connector.bungeecord.bootstrap.BungeeCordConnectorBootstrap

--- a/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/MinestomConnector.kt
+++ b/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/MinestomConnector.kt
@@ -1,8 +1,10 @@
 package dev.redicloud.connector.minestom
 
 import dev.redicloud.api.provider.IServerPlayerProvider
+import dev.redicloud.connector.minestom.player.MinestomPlayerExecutor
 import dev.redicloud.connector.minestom.provider.MinestomScreenProvider
 import dev.redicloud.connector.minestom.provider.MinestomServerPlayerProvider
+import dev.redicloud.service.base.player.BasePlayerExecutor
 import dev.redicloud.service.minecraft.MinecraftServerService
 import dev.redicloud.service.minecraft.provider.AbstractScreenProvider
 import kotlinx.coroutines.runBlocking
@@ -16,6 +18,8 @@ class MinestomConnector(val extension: Extension) : MinecraftServerService<Exten
         = MinestomScreenProvider(this.packetManager, this.extension)
     override var playerProvider: IServerPlayerProvider
         = MinestomServerPlayerProvider()
+    override val playerExecutor: BasePlayerExecutor
+        = MinestomPlayerExecutor(this.playerRepository, this.serverRepository, this.packetManager, this.serviceId)
 
     init {
         initApi()

--- a/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/player/MinestomPlayerExecutor.kt
+++ b/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/player/MinestomPlayerExecutor.kt
@@ -1,0 +1,37 @@
+package dev.redicloud.connector.minestom.player
+
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.player.ICloudPlayer
+import dev.redicloud.api.player.ICloudPlayerRepository
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.server.ICloudServer
+import dev.redicloud.api.service.server.ICloudServerRepository
+import dev.redicloud.service.base.player.BasePlayerExecutor
+import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+import net.minestom.server.MinecraftServer
+import net.minestom.server.adventure.audience.Audiences
+
+class MinestomPlayerExecutor(
+    playerRepository: ICloudPlayerRepository,
+    serverRepository: ICloudServerRepository,
+    packetManager: IPacketManager,
+    thisServiceId: ServiceId
+) : BasePlayerExecutor(playerRepository, serverRepository, packetManager, thisServiceId) {
+
+    override fun audience(player: ICloudPlayer): Audience {
+        val minestomPlayer = MinecraftServer.getConnectionManager().getOnlinePlayerByUuid(player.uniqueId)!!
+        return Audiences.players { it.uuid == minestomPlayer.uuid }
+    }
+
+    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        runBlocking { this@MinestomPlayerExecutor.connect(cloudPlayer, server) }
+    }
+
+    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        runBlocking { this@MinestomPlayerExecutor.executeKick(cloudPlayer, reason) }
+    }
+
+
+}

--- a/connectors/minestom-connector/src/main/resources/extension.json
+++ b/connectors/minestom-connector/src/main/resources/extension.json
@@ -1,7 +1,7 @@
 {
   "entrypoint": "dev.redicloud.connector.minestom.bootstrap.MinestomConnectorBootstrap",
   "name": "redicloud_connector",
-  "version": "2.3.7-SNAPSHOT",
+  "version": "2.4.0-SNAPSHOT",
   "dependencies": [],
   "externalDependencies": {
     "repositories": [],

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
@@ -12,18 +12,21 @@ import dev.redicloud.repository.server.CloudMinecraftServer
 import dev.redicloud.service.minecraft.ProxyServerService
 import dev.redicloud.service.minecraft.provider.AbstractScreenProvider
 import dev.redicloud.api.service.ServiceId
+import dev.redicloud.connector.velocity.player.VelocityPlayerExecutor
+import dev.redicloud.service.base.player.BasePlayerExecutor
 import kotlinx.coroutines.runBlocking
 import java.net.InetSocketAddress
 
 class VelocityConnector(
     private val bootstrap: VelocityConnectorBootstrap,
-    val proxyServer: ProxyServer
+    private val proxyServer: ProxyServer
 ) : ProxyServerService<PluginContainer, ServerInfo>() {
 
 
     internal var velocityShuttingDown: Boolean = false
     override var playerProvider: IServerPlayerProvider = VelocityServerPlayerProvider(proxyServer)
     override val screenProvider: AbstractScreenProvider = VelocityScreenProvider(this.packetManager, this.proxyServer)
+    override val playerExecutor: BasePlayerExecutor = VelocityPlayerExecutor(this.proxyServer, this.playerRepository, this.serverRepository, this.packetManager, this.serviceId)
 
     init {
         initApi()

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/bootstrap/VelocityConnectorBootstrap.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/bootstrap/VelocityConnectorBootstrap.kt
@@ -19,7 +19,7 @@ import kotlin.system.exitProcess
 @Plugin(
     id = "redicloud-connector",
     name = "redicloud-connector-velocity",
-    version = "2.3.7-SNAPSHOT",
+    version = "2.4.0-SNAPSHOT",
     url = "https://redicloud.dev",
     authors = ["RediCloud"]
 )

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/player/VelocityPlayerExecutor.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/player/VelocityPlayerExecutor.kt
@@ -1,0 +1,47 @@
+package dev.redicloud.connector.velocity.player
+
+import com.velocitypowered.api.proxy.ProxyServer
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.player.ICloudPlayer
+import dev.redicloud.api.player.ICloudPlayerRepository
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.server.ICloudServer
+import dev.redicloud.api.service.server.ICloudServerRepository
+import dev.redicloud.service.base.player.BasePlayerExecutor
+import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+import kotlin.jvm.optionals.getOrNull
+
+class VelocityPlayerExecutor(
+    private val proxyServer: ProxyServer,
+    playerRepository: ICloudPlayerRepository,
+    serverRepository: ICloudServerRepository,
+    packetManager: IPacketManager,
+    thisServiceId: ServiceId
+) : BasePlayerExecutor(playerRepository, serverRepository, packetManager, thisServiceId) {
+
+    override fun audience(player: ICloudPlayer): Audience {
+        return proxyServer.getPlayer(player.uniqueId).getOrNull()!!
+    }
+
+    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        val player = proxyServer.getPlayer(cloudPlayer.uniqueId).getOrNull()
+        if (player == null || !player.isActive) {
+            runBlocking { this@VelocityPlayerExecutor.connect(cloudPlayer, server) }
+            return
+        }
+        val serverInfo = proxyServer.getServer(server.name).getOrNull() ?: return
+        player.createConnectionRequest(serverInfo).fireAndForget()
+    }
+
+    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        val player = proxyServer.getPlayer(cloudPlayer.uniqueId).getOrNull()
+        if (player == null || !player.isActive) {
+            runBlocking { this@VelocityPlayerExecutor.kick(cloudPlayer, reason) }
+            return
+        }
+        player.disconnect(reason)
+    }
+
+}

--- a/deploy.kts
+++ b/deploy.kts
@@ -8,7 +8,7 @@ import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
 
-val version = "2.3.7-SNAPSHOT"
+val version = "2.4.0-SNAPSHOT"
 val build = System.getenv("build_number") ?: "local"
 val git = System.getenv("build_vcs_number") ?: "unknown"
 val branch = System.getenv("branch")?.replace("refs/heads/", "") ?: "local"

--- a/examples/example-module/src/main/resources/module.json
+++ b/examples/example-module/src/main/resources/module.json
@@ -1,7 +1,7 @@
 {
   "name": "example-module",
   "id": "example-module",
-  "version": "2.3.7-SNAPSHOT",
+  "version": "2.4.0-SNAPSHOT",
   "description": "An example module for redicloud",
   "website": "https://redocloud.dev/",
   "authors": [

--- a/examples/example-plugin/build.gradle.kts
+++ b/examples/example-plugin/build.gradle.kts
@@ -27,4 +27,5 @@ dependencies {
 
     // Internal usage, ignore it! You don't need to add this
     compileOnly(project(":apis:base-api"))
+    compileOnly(BuildDependencies.KYORI_ADVENTURE_API)
 }

--- a/modules/papermc-updater/src/main/resources/module.json
+++ b/modules/papermc-updater/src/main/resources/module.json
@@ -2,7 +2,7 @@
   "id": "papermc-updater",
   "name": "PaperMC Updater",
   "description": "A simple module to automatically update software (Velocity, Paper, Folia, Waterfall) to the latest version.",
-  "version": "2.3.7-SNAPSHOT",
+  "version": "2.4.0-SNAPSHOT",
   "website": "https://docs.redicloud.dev/modules/papermc-updater",
   "authors": [
     "Suqatri"

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerProcess.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerProcess.kt
@@ -21,7 +21,7 @@ import dev.redicloud.repository.server.ServerRepository
 import dev.redicloud.repository.server.version.CloudServerVersionType
 import dev.redicloud.server.factory.screens.ServerScreen
 import dev.redicloud.server.factory.utils.*
-import dev.redicloud.service.base.packets.CloudServiceShutdownPacket
+import dev.redicloud.service.base.packets.service.CloudServiceShutdownPacket
 import dev.redicloud.service.base.utils.ClusterConfiguration
 import dev.redicloud.utils.blockPort
 import dev.redicloud.utils.findFreePort

--- a/services/base-service/build.gradle.kts
+++ b/services/base-service/build.gradle.kts
@@ -29,4 +29,6 @@ dependencies {
 
     dependency(BuildDependencies.KOTLINX_COROUTINES)
     dependency(BuildDependencies.REDISSON)
+    compileOnly(BuildDependencies.KYORI_ADVENTURE_API)
+    dependency(BuildDependencies.KYORI_ADVENTURE_SERIALIZER_GSON)
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/BaseService.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/BaseService.kt
@@ -8,6 +8,7 @@ import dev.redicloud.api.packets.IPacketManager
 import dev.redicloud.cache.tasks.InvalidCacheTask
 import dev.redicloud.api.packets.PacketListener
 import dev.redicloud.api.java.ICloudJavaVersionRepository
+import dev.redicloud.api.player.ICloudPlayerExecutor
 import dev.redicloud.api.player.ICloudPlayerRepository
 import dev.redicloud.api.service.node.ICloudNodeRepository
 import dev.redicloud.api.service.server.ICloudServerRepository
@@ -18,7 +19,6 @@ import dev.redicloud.commands.api.PARSERS
 import dev.redicloud.commands.api.SUGGESTERS
 import dev.redicloud.repository.node.NodeRepository
 import dev.redicloud.database.DatabaseConnection
-import dev.redicloud.database.codec.GsonCodec
 import dev.redicloud.database.config.DatabaseConfiguration
 import dev.redicloud.event.EventManager
 import dev.redicloud.logging.LogManager
@@ -58,6 +58,12 @@ import dev.redicloud.api.version.IVersionRepository
 import dev.redicloud.console.Console
 import dev.redicloud.modules.ModuleHandler
 import dev.redicloud.repository.server.version.serverversion.VersionRepository
+import dev.redicloud.service.base.packets.ping.ServicePingPacket
+import dev.redicloud.service.base.packets.ping.ServicePingResponse
+import dev.redicloud.service.base.packets.player.*
+import dev.redicloud.service.base.packets.service.CloudServiceShutdownPacket
+import dev.redicloud.service.base.packets.service.CloudServiceShutdownResponse
+import dev.redicloud.service.base.player.BasePlayerExecutor
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -93,6 +99,7 @@ abstract class BaseService(
     val taskManager: CloudTaskManager
     val clusterConfiguration: ClusterConfiguration
     abstract val moduleHandler: ModuleHandler
+    abstract val playerExecutor: BasePlayerExecutor
 
     init {
         runBlocking {
@@ -222,6 +229,15 @@ abstract class BaseService(
         packetManager.registerPacket(CloudServiceShutdownResponse::class)
         packetManager.registerPacket(ClusterMessagePacket::class)
         packetManager.registerPacket(ScreenCommandPacket::class)
+        packetManager.registerPacket(CloudPlayerBookPacket::class)
+        packetManager.registerPacket(CloudPlayerBookPacket::class)
+        packetManager.registerPacket(CloudPlayerConnectServerPacket::class)
+        packetManager.registerPacket(CloudPlayerKickPacket::class)
+        packetManager.registerPacket(CloudPlayerHeaderFooterPacket::class)
+        packetManager.registerPacket(CloudPlayerMessagePacket::class)
+        packetManager.registerPacket(CloudPlayerResourcePackPacket::class)
+        packetManager.registerPacket(CloudPlayerSoundPacket::class)
+        packetManager.registerPacket(CloudPlayerTitlePacket::class)
     }
 
     private fun registerPacketListeners() {
@@ -253,6 +269,7 @@ abstract class BaseService(
         }
         bind(ClusterConfiguration::class).toInstance(clusterConfiguration)
         bind(IDatabaseConnection::class).toInstance(databaseConnection)
+        bind(ICloudPlayerExecutor::class).toInstance(playerExecutor)
     }
 
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/listener/CloudServiceShutdownPacketListener.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/listener/CloudServiceShutdownPacketListener.kt
@@ -1,8 +1,8 @@
 package dev.redicloud.service.base.packets.listener
 
 import dev.redicloud.api.packets.PacketListener
-import dev.redicloud.service.base.packets.CloudServiceShutdownPacket
-import dev.redicloud.service.base.packets.CloudServiceShutdownResponse
+import dev.redicloud.service.base.packets.service.CloudServiceShutdownPacket
+import dev.redicloud.service.base.packets.service.CloudServiceShutdownResponse
 import dev.redicloud.logging.LogManager
 import dev.redicloud.service.base.BaseService
 import kotlinx.coroutines.runBlocking

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ping/ServicePingPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ping/ServicePingPacket.kt
@@ -1,4 +1,4 @@
-package dev.redicloud.service.base.packets
+package dev.redicloud.service.base.packets.ping
 
 import dev.redicloud.api.packets.AbstractPacket
 import dev.redicloud.api.packets.IPacketManager

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ping/ServicePingResponse.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ping/ServicePingResponse.kt
@@ -1,4 +1,4 @@
-package dev.redicloud.service.base.packets
+package dev.redicloud.service.base.packets.ping
 
 import dev.redicloud.api.packets.AbstractPacket
 

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerBookPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerBookPacket.kt
@@ -1,0 +1,35 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import java.util.UUID
+
+class CloudPlayerBookPacket(
+    uniqueId: UUID,
+    private val jsonTitle: String,
+    private val jsonAuthor: String,
+    private val jsonPages: List<String>
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, book: Book) : this(
+        uniqueId,
+        GsonComponentSerializer.gson().serialize(book.title()),
+        GsonComponentSerializer.gson().serialize(book.author()),
+        book.pages().map { GsonComponentSerializer.gson().serialize(it) }
+    )
+
+    private val title: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonTitle)
+
+    private val author: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonAuthor)
+
+    private val pages: List<Component>
+        get() = jsonPages.map { GsonComponentSerializer.gson().deserialize(it) }
+
+    fun createBook(): Book {
+        return Book.book(title, author, pages)
+    }
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerBossBarPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerBossBarPacket.kt
@@ -1,0 +1,49 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.bossbar.BossBar
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import java.util.UUID
+
+class CloudPlayerBossBarPacket(
+    uniqueId: UUID,
+    private val jsonComponent: String,
+    private val colorName: String,
+    private val overlayName: String,
+    val progress: Float,
+    private val flagsName: List<String>,
+    val hide: Boolean = false
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, bossBar: BossBar, hide: Boolean = false) : this(
+        uniqueId,
+        GsonComponentSerializer.gson().serialize(bossBar.name()),
+        bossBar.color().name,
+        bossBar.overlay().name,
+        bossBar.progress(),
+        bossBar.flags().map { it.name }
+    )
+
+    private val component: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonComponent)
+
+    private val color: BossBar.Color
+        get() = BossBar.Color.valueOf(colorName)
+
+    private val overlay: BossBar.Overlay
+        get() = BossBar.Overlay.valueOf(overlayName)
+
+    private val flags: List<BossBar.Flag>
+        get() = flagsName.map { BossBar.Flag.valueOf(it) }
+
+    fun createBossBar(): BossBar {
+        return BossBar.bossBar(
+            this.component,
+            this.progress,
+            this.color,
+            this.overlay,
+            flags.toSet()
+        )
+    }
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerConnectServerPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerConnectServerPacket.kt
@@ -1,0 +1,17 @@
+package dev.redicloud.service.base.packets.player
+
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.server.ICloudServer
+import java.util.UUID
+
+class CloudPlayerConnectServerPacket(
+    uniqueId: UUID,
+    val serviceId: ServiceId
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, cloudServer: ICloudServer) : this(
+        uniqueId,
+        cloudServer.serviceId
+    )
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerHeaderFooterPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerHeaderFooterPacket.kt
@@ -1,0 +1,25 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import java.util.UUID
+
+class CloudPlayerHeaderFooterPacket(
+    uniqueId: UUID,
+    private val jsonHeader: String,
+    private val jsonFooter: String
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, header: Component, footer: Component) : this (
+        uniqueId,
+        GsonComponentSerializer.gson().serialize(header),
+        GsonComponentSerializer.gson().serialize(footer)
+    )
+
+    val header: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonHeader)
+
+    val footer: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonFooter)
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerKickPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerKickPacket.kt
@@ -1,0 +1,20 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import java.util.UUID
+
+class CloudPlayerKickPacket(
+    uniqueId: UUID,
+    private val jsonReason: String
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, reason: Component) : this(
+        uniqueId,
+        GsonComponentSerializer.gson().serialize(reason)
+    )
+
+    val reason: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonReason)
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerMessagePacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerMessagePacket.kt
@@ -1,0 +1,16 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import java.util.*
+
+class CloudPlayerMessagePacket(
+    uniqueId: UUID,
+    private val jsonComponent: String
+) : CloudPlayerPacket(uniqueId) {
+    constructor(uniqueId: UUID, component: Component) : this(uniqueId, GsonComponentSerializer.gson().serialize(component))
+
+    val component: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonComponent)
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerPacket.kt
@@ -1,0 +1,8 @@
+package dev.redicloud.service.base.packets.player
+
+import dev.redicloud.api.packets.AbstractPacket
+import java.util.UUID
+
+open class CloudPlayerPacket(
+    val uniqueId: UUID
+) : AbstractPacket()

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerResourcePackPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerResourcePackPacket.kt
@@ -1,0 +1,38 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.resource.ResourcePackInfo
+import net.kyori.adventure.resource.ResourcePackRequest
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import java.net.URI
+import java.util.UUID
+
+class CloudPlayerResourcePackPacket(
+    uniqueId: UUID,
+    private val jsonPrompt: String?,
+    private val required: Boolean,
+    private val stringRequests: Map<UUID, Pair<URI, String>>
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, resourcePackPacket: ResourcePackRequest) : this(
+        uniqueId,
+        resourcePackPacket.prompt()?.let { GsonComponentSerializer.gson().serialize(it) },
+        resourcePackPacket.required(),
+        resourcePackPacket.packs().associate { it.id() to Pair(it.uri(), it.hash()) }
+    )
+
+    private val prompt: Component?
+        get() = jsonPrompt?.let { GsonComponentSerializer.gson().deserialize(it) }
+
+    private val requests: List<ResourcePackInfo>
+        get() = stringRequests.map { (id, pair) -> ResourcePackInfo.resourcePackInfo(id, pair.first, pair.second) }
+
+    fun createResourcePackRequest(): ResourcePackRequest {
+        return ResourcePackRequest.resourcePackRequest()
+            .packs(requests)
+            .prompt(prompt)
+            .required(required)
+            .build()
+    }
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerSoundPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerSoundPacket.kt
@@ -1,0 +1,35 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.key.Key
+import net.kyori.adventure.sound.Sound
+import java.util.*
+
+class CloudPlayerSoundPacket(
+    uniqueId: UUID,
+    private val soundName: String,
+    private val sourceName: String,
+    val volume: Float,
+    val pitch: Float,
+    val stop: Boolean = false
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, sound: Sound, stop: Boolean = false) : this(
+        uniqueId,
+        sound.name().asString(),
+        sound.source().name,
+        sound.volume(),
+        sound.pitch(),
+        stop
+    )
+
+    val key: Key
+        get() = Key.key(soundName)
+
+    val source: Sound.Source
+        get() = Sound.Source.valueOf(sourceName)
+
+    fun createSound(): Sound {
+        return Sound.sound(key, source, volume, pitch)
+    }
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerTitlePacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/player/CloudPlayerTitlePacket.kt
@@ -1,0 +1,41 @@
+package dev.redicloud.service.base.packets.player
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.kyori.adventure.title.Title
+import net.kyori.adventure.title.Title.Times
+import java.time.Duration
+import java.util.UUID
+
+class CloudPlayerTitlePacket(
+    uniqueId: UUID,
+    private val jsonTitle: String,
+    private val jsonSubTitle: String,
+    private val fadeIn: Duration,
+    private val stay: Duration,
+    private val fadeOut: Duration
+) : CloudPlayerPacket(uniqueId) {
+
+    constructor(uniqueId: UUID, title: Title) : this(
+        uniqueId,
+        GsonComponentSerializer.gson().serialize(title.title()),
+        GsonComponentSerializer.gson().serialize(title.subtitle()),
+        title.times()?.fadeIn() ?: Title.DEFAULT_TIMES.fadeIn(),
+        title.times()?.stay() ?: Title.DEFAULT_TIMES.stay(),
+        title.times()?.fadeOut() ?: Title.DEFAULT_TIMES.fadeOut()
+    )
+
+    private val title: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonTitle)
+
+    private val subTitle: Component
+        get() = GsonComponentSerializer.gson().deserialize(jsonSubTitle)
+
+    private val times: Times
+        get() = Times.times(fadeIn, stay, fadeOut)
+
+    fun createTitle(): Title {
+        return Title.title(title, subTitle, times)
+    }
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/service/CloudServiceShutdownPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/service/CloudServiceShutdownPacket.kt
@@ -1,4 +1,4 @@
-package dev.redicloud.service.base.packets
+package dev.redicloud.service.base.packets.service
 
 import dev.redicloud.api.packets.AbstractPacket
 

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/service/CloudServiceShutdownResponse.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/service/CloudServiceShutdownResponse.kt
@@ -1,4 +1,4 @@
-package dev.redicloud.service.base.packets
+package dev.redicloud.service.base.packets.service
 
 import dev.redicloud.api.packets.AbstractPacket
 

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/BasePlayerExecutor.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/BasePlayerExecutor.kt
@@ -1,0 +1,245 @@
+package dev.redicloud.service.base.player
+
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.player.ICloudPlayer
+import dev.redicloud.api.player.ICloudPlayerExecutor
+import dev.redicloud.api.player.ICloudPlayerRepository
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.ServiceType
+import dev.redicloud.api.service.server.ICloudServer
+import dev.redicloud.api.service.server.ICloudServerRepository
+import dev.redicloud.service.base.packets.player.*
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.bossbar.BossBar
+import net.kyori.adventure.inventory.Book
+import net.kyori.adventure.resource.ResourcePackRequest
+import net.kyori.adventure.sound.Sound
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.title.Title
+import java.util.*
+
+abstract class BasePlayerExecutor(
+    private val playerRepository: ICloudPlayerRepository,
+    private val serverRepository: ICloudServerRepository,
+    private val packetManager: IPacketManager,
+    private val thisServiceId: ServiceId
+) : ICloudPlayerExecutor {
+
+    init {
+        PlayerExecutorListener(this, this.packetManager)
+    }
+
+    override suspend fun sendMessage(uniqueId: UUID, component: Component) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.sendMessage(player, component)
+    }
+
+    override suspend fun sendMessage(cloudPlayer: ICloudPlayer, component: Component) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).sendMessage(component)
+            return
+        }
+        val packet = CloudPlayerMessagePacket(cloudPlayer.uniqueId, component)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun showBossBar(uniqueId: UUID, bossBar: BossBar) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.showBossBar(player, bossBar)
+    }
+
+    override suspend fun showBossBar(cloudPlayer: ICloudPlayer, bossBar: BossBar) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).showBossBar(bossBar)
+            return
+        }
+        val packet = CloudPlayerBossBarPacket(cloudPlayer.uniqueId, bossBar)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun hideBossBar(uniqueId: UUID, bossBar: BossBar) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.hideBossBar(player, bossBar)
+    }
+
+    override suspend fun hideBossBar(cloudPlayer: ICloudPlayer, bossBar: BossBar) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).hideBossBar(bossBar)
+            return
+        }
+        val packet = CloudPlayerBossBarPacket(cloudPlayer.uniqueId, bossBar, true)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun playSound(uniqueId: UUID, sound: Sound) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.playSound(player, sound)
+    }
+
+    override suspend fun playSound(
+        cloudPlayer: ICloudPlayer,
+        sound: Sound
+    ) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).playSound(sound)
+            return
+        }
+        val packet = CloudPlayerSoundPacket(cloudPlayer.uniqueId, sound)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun stopSound(uniqueId: UUID, sound: Sound) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.stopSound(player, sound)
+    }
+
+    override suspend fun stopSound(cloudPlayer: ICloudPlayer, sound: Sound) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).stopSound(sound)
+            return
+        }
+        val packet = CloudPlayerSoundPacket(cloudPlayer.uniqueId, sound, true)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun showTitle(uniqueId: UUID, title: Title) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.showTitle(player, title)
+    }
+
+    override suspend fun showTitle(cloudPlayer: ICloudPlayer, title: Title) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).showTitle(title)
+            return
+        }
+        val packet = CloudPlayerTitlePacket(cloudPlayer.uniqueId, title)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun showBook(uniqueId: UUID, book: Book) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.showBook(player, book)
+    }
+
+    override suspend fun showBook(cloudPlayer: ICloudPlayer, book: Book) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).openBook(book)
+            return
+        }
+        val packet = CloudPlayerBookPacket(cloudPlayer.uniqueId, book)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun sendPlayerListHeaderAndFooter(uniqueId: UUID, header: Component, footer: Component) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.sendPlayerListHeaderAndFooter(player, header, footer)
+    }
+
+    override suspend fun sendPlayerListHeaderAndFooter(
+        cloudPlayer: ICloudPlayer,
+        header: Component,
+        footer: Component
+    ) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).sendPlayerListHeaderAndFooter(header, footer)
+            return
+        }
+        val packet = CloudPlayerHeaderFooterPacket(cloudPlayer.uniqueId, header, footer)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun sendResourcePacks(uniqueId: UUID, resourcePackRequest: ResourcePackRequest) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.sendResourcePacks(player, resourcePackRequest)
+    }
+
+    override suspend fun sendResourcePacks(cloudPlayer: ICloudPlayer, resourcePackRequest: ResourcePackRequest) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.audience(cloudPlayer).sendResourcePacks(resourcePackRequest)
+            return
+        }
+        val packet = CloudPlayerResourcePackPacket(cloudPlayer.uniqueId, resourcePackRequest)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun connect(uniqueId: UUID, serviceId: ServiceId) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.connect(player, serviceId)
+    }
+
+    override suspend fun connect(uniqueId: UUID, serverName: String) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.connect(player, serverName)
+    }
+
+    override suspend fun connect(cloudPlayer: ICloudPlayer, serverName: String) {
+        val server = serverRepository.getServer<ICloudServer>(serverName, ServiceType.MINECRAFT_SERVER)
+            ?: throw NullPointerException("Server with name $serverName not found")
+        this.connect(cloudPlayer, server)
+    }
+
+    override suspend fun connect(cloudPlayer: ICloudPlayer, serviceId: ServiceId) {
+        if (serviceId.type != ServiceType.MINECRAFT_SERVER) {
+            throw IllegalArgumentException("ServiceId type must be MINECRAFT_SERVER")
+        }
+        val server = serverRepository.getServer<ICloudServer>(serviceId)
+            ?: throw NullPointerException("Server with serviceId $serviceId not found")
+        this.connect(cloudPlayer, server)
+    }
+
+    override suspend fun connect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        if (server.serviceId.type != ServiceType.MINECRAFT_SERVER) {
+            throw IllegalArgumentException("Server type must be MINECRAFT_SERVER")
+        }
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.executeConnect(cloudPlayer, server)
+            return
+        }
+        val packet = CloudPlayerConnectServerPacket(cloudPlayer.uniqueId, server.serviceId)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    override suspend fun kick(uniqueId: UUID, reason: Component) {
+        val player = playerRepository.getPlayer(uniqueId)
+            ?: throw NullPointerException("Player with uniqueId $uniqueId not found")
+        this.kick(player, reason)
+    }
+
+    override suspend fun kick(cloudPlayer: ICloudPlayer, reason: Component) {
+        if (!cloudPlayer.connected || cloudPlayer.proxyId == null) return
+        if (cloudPlayer.proxyId == thisServiceId) {
+            this.executeKick(cloudPlayer, reason)
+            return
+        }
+        val packet = CloudPlayerKickPacket(cloudPlayer.uniqueId, reason)
+        packetManager.publish(packet, cloudPlayer.proxyId!!)
+    }
+
+    abstract fun audience(player: ICloudPlayer): Audience
+
+    abstract fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer)
+
+    abstract fun executeKick(cloudPlayer: ICloudPlayer, reason: Component)
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/PlayerExecutorListener.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/PlayerExecutorListener.kt
@@ -1,0 +1,72 @@
+package dev.redicloud.service.base.player
+
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.packets.listen
+import dev.redicloud.api.player.ICloudPlayerExecutor
+import dev.redicloud.service.base.packets.player.*
+import kotlinx.coroutines.runBlocking
+
+class PlayerExecutorListener(
+    private val playerExecutor: ICloudPlayerExecutor,
+    packetManager: IPacketManager
+) {
+
+    val bookPacketListener = packetManager.listen<CloudPlayerBookPacket> {
+        runBlocking {
+            playerExecutor.showBook(it.uniqueId, it.createBook())
+        }
+    }
+
+    val bossBarPacketListener = packetManager.listen<CloudPlayerBossBarPacket> {
+        runBlocking {
+            if (it.hide) {
+                playerExecutor.hideBossBar(it.uniqueId, it.createBossBar())
+            } else {
+                playerExecutor.showBossBar(it.uniqueId, it.createBossBar())
+            }
+        }
+    }
+
+    val connectServerPacketListener = packetManager.listen<CloudPlayerConnectServerPacket> {
+        runBlocking {
+            playerExecutor.connect(it.uniqueId, it.serviceId)
+        }
+    }
+
+    val headerFooterPacketListener = packetManager.listen<CloudPlayerHeaderFooterPacket> {
+        runBlocking {
+            playerExecutor.sendPlayerListHeaderAndFooter(it.uniqueId, it.header, it.footer)
+        }
+    }
+
+    val kickPacketListener = packetManager.listen<CloudPlayerKickPacket> {
+        runBlocking {
+            playerExecutor.kick(it.uniqueId, it.reason)
+        }
+    }
+
+    val messagePacketLister = packetManager.listen<CloudPlayerMessagePacket> {
+        runBlocking {
+            playerExecutor.sendMessage(it.uniqueId, it.component)
+        }
+    }
+
+    val resourcePacketListener = packetManager.listen<CloudPlayerResourcePackPacket> {
+        runBlocking {
+            playerExecutor.sendResourcePacks(it.uniqueId, it.createResourcePackRequest())
+        }
+    }
+
+    val soundPacketListener = packetManager.listen<CloudPlayerSoundPacket> {
+        runBlocking {
+            playerExecutor.playSound(it.uniqueId, it.createSound())
+        }
+    }
+
+    val titlePacketListener = packetManager.listen<CloudPlayerTitlePacket> {
+        runBlocking {
+            playerExecutor.showTitle(it.uniqueId, it.createTitle())
+        }
+    }
+
+}

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/repository/_ServiceRepository.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/repository/_ServiceRepository.kt
@@ -4,8 +4,8 @@ import dev.redicloud.repository.node.NodeRepository
 import dev.redicloud.repository.server.ServerRepository
 import dev.redicloud.repository.service.CachedServiceRepository
 import dev.redicloud.repository.service.ServiceRepository
-import dev.redicloud.service.base.packets.ServicePingPacket
-import dev.redicloud.service.base.packets.ServicePingResponse
+import dev.redicloud.service.base.packets.ping.ServicePingPacket
+import dev.redicloud.service.base.packets.ping.ServicePingResponse
 import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.ServiceType
 import kotlin.time.Duration.Companion.seconds

--- a/services/node-service/build.gradle.kts
+++ b/services/node-service/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     shade(project(":updater"))
     shade(BuildDependencies.LOGBACK_CLASSIC)
     shade(BuildDependencies.LOGBACK_CORE)
+    dependency(BuildDependencies.KYORI_ADVENTURE_API)
     compileOnly(BuildDependencies.JLINE_JANSI)
     compileOnly(BuildDependencies.JSCH)
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
@@ -31,7 +31,9 @@ import dev.redicloud.service.node.tasks.metrics.MetricsTask
 import dev.redicloud.api.utils.TEMP_FOLDER
 import dev.redicloud.console.Console
 import dev.redicloud.modules.ModuleHandler
+import dev.redicloud.service.base.player.BasePlayerExecutor
 import dev.redicloud.service.node.listener.ConfigurationUpdateServerListener
+import dev.redicloud.service.node.player.NodePlayerExecutor
 import dev.redicloud.service.node.tasks.player.PlayerProxyConnectionStateTask
 import dev.redicloud.service.node.tasks.service.CloudInvalidServerUnregisterTask
 import dev.redicloud.updater.Updater
@@ -47,9 +49,10 @@ class NodeService(
     val firstStart: Boolean = false
 ) : BaseService(databaseConfiguration, databaseConnection, configuration.toServiceId()) {
 
-    final override val fileTemplateRepository: NodeFileTemplateRepository
-    final override val serverVersionTypeRepository: CloudServerVersionTypeRepository
-    final override val moduleHandler: ModuleHandler
+    override val fileTemplateRepository: NodeFileTemplateRepository
+    override val serverVersionTypeRepository: CloudServerVersionTypeRepository
+    override val moduleHandler: ModuleHandler
+    override val playerExecutor: NodePlayerExecutor
     val console: NodeConsole
     val fileNodeRepository: FileNodeRepository
     val fileCluster: FileCluster
@@ -63,6 +66,7 @@ class NodeService(
         serverVersionTypeRepository = CloudServerVersionTypeRepository(databaseConnection, console, packetManager)
         serverFactory = ServerFactory(databaseConnection, nodeRepository, serverRepository, serverVersionRepository, serverVersionTypeRepository, fileTemplateRepository, javaVersionRepository, packetManager, configuration.hostAddress, console, clusterConfiguration, configurationTemplateRepository, eventManager, fileCluster)
         moduleHandler = ModuleHandler(serviceId, loadModuleRepositoryUrls(), eventManager, packetManager, null, databaseConnection)
+        playerExecutor = NodePlayerExecutor(this.playerRepository, serverRepository, packetManager, serviceId)
 
         runBlocking {
             registerDefaults()

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/player/NodePlayerExecutor.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/player/NodePlayerExecutor.kt
@@ -1,0 +1,33 @@
+package dev.redicloud.service.node.player
+
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.player.ICloudPlayer
+import dev.redicloud.api.player.ICloudPlayerRepository
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.server.ICloudServer
+import dev.redicloud.api.service.server.ICloudServerRepository
+import dev.redicloud.service.base.player.BasePlayerExecutor
+import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.audience.Audience
+import net.kyori.adventure.text.Component
+
+class NodePlayerExecutor(
+    playerRepository: ICloudPlayerRepository,
+    serverRepository: ICloudServerRepository,
+    packetManager: IPacketManager,
+    thisServiceId: ServiceId
+) : BasePlayerExecutor(playerRepository, serverRepository, packetManager, thisServiceId) {
+
+    override fun audience(player: ICloudPlayer): Audience {
+        throw UnsupportedOperationException("Not supported for node service")
+    }
+
+    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        runBlocking { this@NodePlayerExecutor.connect(cloudPlayer, server) }
+    }
+
+    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        runBlocking { this@NodePlayerExecutor.kick(cloudPlayer, reason) }
+    }
+
+}


### PR DESCRIPTION
added following api functions to [ICloudPlayerExecutor](https://github.com/RediCloud/cloud-v2/blob/feat/player-executor/apis/base-api/src/main/kotlin/dev/redicloud/api/player/ICloudPlayerExecutor.kt):
- sendMessage
- showBossBar
- hideBossBar
- playSound
- stopSound
- showTitle
- showBook
- sendPlayerListHeaderAndFooter
- sendResourcePackets
- connect
- kick