### PR TITLE
refactor: coroutine safety & structured concurrency

### DIFF
--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/AbstractCommandSuggester.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/AbstractCommandSuggester.kt
@@ -12,8 +12,8 @@ abstract class AbstractCommandSuggester {
         suggest(it!!)
     }
 
-    fun preSuggest(context: CommandContext): Array<String> {
-        return cache.getBlocking(context)!!
+    suspend fun preSuggest(context: CommandContext): Array<String> {
+        return cache.get(context)!!
     }
 
     /**
@@ -22,5 +22,5 @@ abstract class AbstractCommandSuggester {
      * @param context The context of the command
      * @return The list of possible arguments
      */
-    abstract fun suggest(context: CommandContext): Array<String>
+    abstract suspend fun suggest(context: CommandContext): Array<String>
 }

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/AbstractCommandSuggester.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/AbstractCommandSuggester.kt
@@ -13,7 +13,7 @@ abstract class AbstractCommandSuggester {
     }
 
     fun preSuggest(context: CommandContext): Array<String> {
-        return cache.get(context)!!
+        return cache.getBlocking(context)!!
     }
 
     /**

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/CommandSuggesters.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/CommandSuggesters.kt
@@ -4,7 +4,7 @@ package dev.redicloud.api.commands
  * An empty suggester that returns an empty array. Used as default argument suggester.
  */
 class EmptySuggester : AbstractCommandSuggester() {
-    override fun suggest(context: CommandContext): Array<String> = arrayOf()
+    override suspend fun suggest(context: CommandContext): Array<String> = arrayOf()
 }
 
 /**
@@ -27,7 +27,7 @@ class MemorySuggester : AbstractCommandSuggester() {
         1048576
     )
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         val totalMemory = Runtime.getRuntime().totalMemory()
         return memoryList.filter { it < totalMemory }.map { it.toString() }.sortedDescending().toTypedArray()
     }
@@ -37,14 +37,14 @@ class MemorySuggester : AbstractCommandSuggester() {
  * A suggester that returns the two possible values for a boolean.
  */
 class BooleanSuggester : AbstractCommandSuggester() {
-    override fun suggest(context: CommandContext): Array<String> = arrayOf("true", "false")
+    override suspend fun suggest(context: CommandContext): Array<String> = arrayOf("true", "false")
 }
 
 /**
  * A suggester that returns integers in a given range if provided. This is an example for annotated parameters.
  */
 class IntegerSuggester : AbstractCommandSuggester() {
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         val min = context.getOr(0, 1)
         val max = context.getOr(1, 10)
         val step = context.getOr(2, 1)

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/ICommandArgumentParser.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/commands/ICommandArgumentParser.kt
@@ -1,5 +1,5 @@
 package dev.redicloud.api.commands
 
 interface ICommandArgumentParser<T> {
-    fun parse(parameter: String): T?
+    suspend fun parse(parameter: String): T?
 }

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/events/IEventManager.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/events/IEventManager.kt
@@ -16,16 +16,16 @@ interface IEventManager {
 
     fun unregisterListener(listener: Any)
 
-    fun fireEvent(event: CloudEvent)
+    suspend fun fireEvent(event: CloudEvent)
 }
 
-inline fun <reified T : CloudEvent> IEventManager.listen(noinline handler: (T) -> Unit): InlineEventCaller<T> {
+inline fun <reified T : CloudEvent> IEventManager.listen(noinline handler: suspend (T) -> Unit): InlineEventCaller<T> {
     val listener = InlineEventCaller(this, T::class, handler)
     registerInlineListener(listener)
     return listener
 }
 
-fun <T : CloudEvent> IEventManager.listen(clazz: KClass<T>, handler: (T) -> Unit): InlineEventCaller<T> {
+fun <T : CloudEvent> IEventManager.listen(clazz: KClass<T>, handler: suspend (T) -> Unit): InlineEventCaller<T> {
     val listener = InlineEventCaller(this, clazz, handler)
     registerInlineListener(listener)
     return listener

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/events/InlineEventCaller.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/events/InlineEventCaller.kt
@@ -1,21 +1,19 @@
 package dev.redicloud.api.events
 
-import dev.redicloud.utils.defaultScope
-import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
 class InlineEventCaller<T : CloudEvent>(
     val eventManager: IEventManager,
     val eventClass: KClass<T>,
-    val handler: (T) -> Unit
+    val handler: suspend (T) -> Unit
 ) {
 
     val classLoader = this::class.java.classLoader
 
     fun unregister() {
-        defaultScope.launch { eventManager.unregisterListener(this@InlineEventCaller) }
+        eventManager.unregisterListener(this@InlineEventCaller)
     }
 
     @CloudEventListener
-    fun listener(event: T) = handler(event)
+    suspend fun listener(event: T) = handler(event)
 }

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/modules/IModuleHandler.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/modules/IModuleHandler.kt
@@ -8,11 +8,11 @@ interface IModuleHandler {
 
     fun isModuleReloadable(moduleId: String): Boolean
 
-    fun reloadModule(moduleId: String)
+    suspend fun reloadModule(moduleId: String)
 
-    fun unloadModule(moduleId: String)
+    suspend fun unloadModule(moduleId: String)
 
-    fun loadModule(moduleId: String)
+    suspend fun loadModule(moduleId: String)
 
     fun getStorage(moduleId: String, name: String): IModuleStorage
 

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/packets/AbstractPacket.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/packets/AbstractPacket.kt
@@ -14,7 +14,7 @@ abstract class AbstractPacket {
     val referenceId: UUID?
         get() = backingReferenceId
 
-    open fun received(manager: IPacketManager) {
+    open suspend fun received(manager: IPacketManager) {
         this.manager = manager
     }
 

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/packets/IPacketManager.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/packets/IPacketManager.kt
@@ -41,13 +41,13 @@ interface IPacketManager {
     suspend fun publishToCategory(packet: AbstractPacket, categoryName: String): IPacketResponse
 }
 
-inline fun <reified T : AbstractPacket> IPacketManager.listen(noinline handler: (T) -> Unit): PacketListener<T> {
+inline fun <reified T : AbstractPacket> IPacketManager.listen(noinline handler: suspend (T) -> Unit): PacketListener<T> {
     val listener = PacketListener(T::class, handler)
     registerListener(listener)
     return listener
 }
 
-fun <T : AbstractPacket> IPacketManager.listen(clazz: KClass<T>, handler: (T) -> Unit): PacketListener<T> {
+fun <T : AbstractPacket> IPacketManager.listen(clazz: KClass<T>, handler: suspend (T) -> Unit): PacketListener<T> {
     val listener = PacketListener(clazz, handler)
     registerListener(listener)
     return listener

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/packets/PacketListener.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/packets/PacketListener.kt
@@ -2,9 +2,9 @@ package dev.redicloud.api.packets
 
 import kotlin.reflect.KClass
 
-open class PacketListener<T : AbstractPacket>(val packetClazz: KClass<T>, private val handle: (T) -> Unit) {
+open class PacketListener<T : AbstractPacket>(val packetClazz: KClass<T>, private val handle: suspend (T) -> Unit) {
 
     val classLoader = this::class.java.classLoader
 
-    fun listener(packet: T) = handle(packet)
+    suspend fun listener(packet: T) = handle(packet)
 }

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/version/IServerVersionHandler.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/version/IServerVersionHandler.kt
@@ -3,7 +3,7 @@ package dev.redicloud.api.version
 import dev.redicloud.api.java.ICloudJavaVersion
 import dev.redicloud.api.utils.MINECRAFT_VERSIONS_FOLDER
 import dev.redicloud.logging.LogManager
-import dev.redicloud.utils.SimpleLock
+import kotlinx.coroutines.sync.Mutex
 import java.io.File
 
 @Suppress("TooManyFunctions")
@@ -42,7 +42,7 @@ interface IServerVersionHandler {
 
     fun register() = registerHandler(this)
 
-    fun getLock(version: ICloudServerVersion): SimpleLock
+    fun getLock(version: ICloudServerVersion): Mutex
 
     suspend fun shutdown(force: Boolean, serverVersionRepository: ICloudServerVersionRepository) {
         serverVersionRepository.getVersions().forEach {

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/version/IServerVersionHandler.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/version/IServerVersionHandler.kt
@@ -4,6 +4,7 @@ import dev.redicloud.api.java.ICloudJavaVersion
 import dev.redicloud.api.utils.MINECRAFT_VERSIONS_FOLDER
 import dev.redicloud.logging.LogManager
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.File
 
 @Suppress("TooManyFunctions")
@@ -50,8 +51,7 @@ interface IServerVersionHandler {
             if (lock.isLocked) {
                 if (!force) {
                     LOGGER.warning("Server version ${it.displayName} currently updating, waiting for it to finish...")
-                    lock.lock()
-                    lock.unlock()
+                    lock.withLock { /* wait for release */ }
                 } else {
                     LOGGER.warning("Server version ${it.displayName} currently updating, but forcing shutdown...")
                 }
@@ -65,15 +65,15 @@ interface IServerVersionHandler {
         val CACHE_HANDLERS = mutableListOf<IServerVersionHandler>()
 
         fun getHandler(type: ICloudServerVersionType): IServerVersionHandler =
-            CACHE_HANDLERS.firstOrNull { it.name.lowercase() == type.versionHandlerName.lowercase() }
+            CACHE_HANDLERS.firstOrNull { it.name.equals(type.versionHandlerName, ignoreCase = true) }
                 ?: getDefaultHandler()
 
         fun getHandlerStrict(name: String): IServerVersionHandler? =
-            CACHE_HANDLERS.firstOrNull { it.name.lowercase() == name.lowercase() }
+            CACHE_HANDLERS.firstOrNull { it.name.equals(name, ignoreCase = true) }
 
         fun registerHandler(serverVersionHandler: IServerVersionHandler): IServerVersionHandler {
-            if (CACHE_HANDLERS.any { it.name.lowercase() == serverVersionHandler.name.lowercase() }) {
-                return CACHE_HANDLERS.first { it.name.lowercase() == serverVersionHandler.name.lowercase() }
+            if (CACHE_HANDLERS.any { it.name.equals(serverVersionHandler.name, ignoreCase = true) }) {
+                return CACHE_HANDLERS.first { it.name.equals(serverVersionHandler.name, ignoreCase = true) }
             }
             CACHE_HANDLERS.add(serverVersionHandler)
             return serverVersionHandler
@@ -88,7 +88,7 @@ interface IServerVersionHandler {
         }
 
         fun unregisterHandler(name: String) {
-            CACHE_HANDLERS.removeIf { it.name.lowercase() == name.lowercase() }
+            CACHE_HANDLERS.removeIf { it.name.equals(name, ignoreCase = true) }
         }
     }
 }

--- a/cache/src/main/kotlin/dev/redicloud/cache/ClusterCache.kt
+++ b/cache/src/main/kotlin/dev/redicloud/cache/ClusterCache.kt
@@ -6,8 +6,8 @@ import dev.redicloud.api.service.ServiceType
 import dev.redicloud.cache.packets.CacheMultiUpdatePacket
 import dev.redicloud.cache.packets.CacheResetPacket
 import dev.redicloud.cache.packets.CacheUpdatePacket
-import dev.redicloud.utils.defaultScope
 import dev.redicloud.utils.gson.gson
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
@@ -20,6 +20,7 @@ class ClusterCache<V : Any>(
     val cacheClass: KClass<V>,
     val cacheDuration: Duration,
     private val packetManager: IPacketManager,
+    private val scope: CoroutineScope,
     vararg val serviceTypes: ServiceType,
 ) {
 
@@ -62,7 +63,7 @@ class ClusterCache<V : Any>(
         if (value == null) {
             if (!isCached(key)) return
             setCached(key, value)
-            defaultScope.launch {
+            scope.launch {
                 serviceTypes.forEach {
                     packetManager.publish(CacheUpdatePacket(name, key, null), it)
                 }
@@ -70,7 +71,7 @@ class ClusterCache<V : Any>(
             return
         }
         setCached(key, value)
-        defaultScope.launch {
+        scope.launch {
             serviceTypes.forEach {
                 packetManager.publish(CacheUpdatePacket(name, key, gson.toJson(value)), it)
             }
@@ -82,7 +83,7 @@ class ClusterCache<V : Any>(
         toUpdate.forEach {
             setCached(it.key, it.value)
         }
-        defaultScope.launch {
+        scope.launch {
             val map = toUpdate.mapValues { gson.toJson(it.value) }
             serviceTypes.forEach {
                 packetManager.publish(CacheMultiUpdatePacket(name, map), it)
@@ -92,7 +93,7 @@ class ClusterCache<V : Any>(
 
     fun clearCache() {
         cache.clear()
-        defaultScope.launch {
+        scope.launch {
             serviceTypes.forEach {
                 packetManager.publish(CacheResetPacket(name), it)
             }

--- a/cache/src/main/kotlin/dev/redicloud/cache/packets/CacheMultiUpdatePacket.kt
+++ b/cache/src/main/kotlin/dev/redicloud/cache/packets/CacheMultiUpdatePacket.kt
@@ -8,7 +8,7 @@ class CacheMultiUpdatePacket(
     val toUpdate: Map<String, String?>
 ) : CachePacket(name) {
 
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         if (cache == null) return
         toUpdate.forEach { (key, valueJson) ->

--- a/cache/src/main/kotlin/dev/redicloud/cache/packets/CachePacket.kt
+++ b/cache/src/main/kotlin/dev/redicloud/cache/packets/CachePacket.kt
@@ -13,7 +13,7 @@ abstract class CachePacket(
     @Expose(deserialize = false, serialize = false)
     var cache: ClusterCache<out IClusterCacheObject>? = null
 
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         cache = ClusterCache.CACHES[cacheName]
     }

--- a/cache/src/main/kotlin/dev/redicloud/cache/packets/CacheResetPacket.kt
+++ b/cache/src/main/kotlin/dev/redicloud/cache/packets/CacheResetPacket.kt
@@ -6,7 +6,7 @@ class CacheResetPacket(
     name: String
 ) : CachePacket(name) {
 
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         if (cache == null) return
         cache!!.resetCache()

--- a/cache/src/main/kotlin/dev/redicloud/cache/packets/CacheUpdatePacket.kt
+++ b/cache/src/main/kotlin/dev/redicloud/cache/packets/CacheUpdatePacket.kt
@@ -9,7 +9,7 @@ class CacheUpdatePacket(
     val valueJson: String?
 ) : CachePacket(name) {
 
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         if (cache == null) return
         if (valueJson == null) {

--- a/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandArgument.kt
+++ b/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandArgument.kt
@@ -105,7 +105,7 @@ class CommandArgument(
             state.argumentIndex + 1 == this.index
         if (predictMatch) return true
 
-        return state.currentBuild.lowercase() == input.lowercase() && state.lastWasThis
+        return state.currentBuild.equals(input, ignoreCase = true) && state.lastWasThis
     }
 
     private fun buildMatchState(pathParts: List<String>, inputParts: List<String>, predict: Boolean): PathMatchState {
@@ -117,7 +117,7 @@ class CommandArgument(
             val inputCurrent = inputParts[state.index]
             if (part.isArgument()) {
                 state.argumentIndex++
-                if (pathFormat.lowercase() == part.lowercase() || part.isEmpty() && predict) {
+                if (pathFormat.equals(part, ignoreCase = true) || part.isEmpty() && predict) {
                     state.lastWasThis = true
                     state.alreadyIndexed = true
                 }
@@ -125,7 +125,7 @@ class CommandArgument(
                 state.currentBuild += inputCurrent
                 return@forEach
             }
-            if (inputCurrent.lowercase() == part.lowercase()) {
+            if (inputCurrent.equals(part, ignoreCase = true)) {
                 if (state.currentBuild.isNotEmpty()) state.currentBuild += " "
                 state.currentBuild += inputCurrent
                 return@forEach
@@ -134,5 +134,5 @@ class CommandArgument(
         return state
     }
 
-    fun parse(input: String): Any? = parser?.parse(input)
+    suspend fun parse(input: String): Any? = parser?.parse(input)
 }

--- a/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandArgumentParser.kt
+++ b/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandArgumentParser.kt
@@ -16,27 +16,27 @@ val PARSERS = mutableMapOf<KClass<*>, ICommandArgumentParser<*>>(
 )
 
 class StringCommandArgumentParser : ICommandArgumentParser<String> {
-    override fun parse(parameter: String): String = parameter
+    override suspend fun parse(parameter: String): String = parameter
 }
 
 class IntCommandArgumentParser : ICommandArgumentParser<Int> {
-    override fun parse(parameter: String): Int? = parameter.toIntOrNull()
+    override suspend fun parse(parameter: String): Int? = parameter.toIntOrNull()
 }
 
 class LongCommandArgumentParser : ICommandArgumentParser<Long> {
-    override fun parse(parameter: String): Long? = parameter.toLongOrNull()
+    override suspend fun parse(parameter: String): Long? = parameter.toLongOrNull()
 }
 
 class DoubleCommandArgumentParser : ICommandArgumentParser<Double> {
-    override fun parse(parameter: String): Double? = parameter.toDoubleOrNull()
+    override suspend fun parse(parameter: String): Double? = parameter.toDoubleOrNull()
 }
 
 class FloatCommandArgumentParser : ICommandArgumentParser<Float> {
-    override fun parse(parameter: String): Float? = parameter.toFloatOrNull()
+    override suspend fun parse(parameter: String): Float? = parameter.toFloatOrNull()
 }
 
 class BooleanCommandArgumentParser : ICommandArgumentParser<Boolean> {
-    override fun parse(parameter: String): Boolean? {
+    override suspend fun parse(parameter: String): Boolean? {
         return when (parameter.lowercase()) {
             "true" -> true
             "yes" -> true
@@ -50,13 +50,13 @@ class BooleanCommandArgumentParser : ICommandArgumentParser<Boolean> {
 }
 
 class ByteCommandArgumentParser : ICommandArgumentParser<Byte> {
-    override fun parse(parameter: String): Byte? = parameter.toByteOrNull()
+    override suspend fun parse(parameter: String): Byte? = parameter.toByteOrNull()
 }
 
 class ShortCommandArgumentParser : ICommandArgumentParser<Short> {
-    override fun parse(parameter: String): Short? = parameter.toShortOrNull()
+    override suspend fun parse(parameter: String): Short? = parameter.toShortOrNull()
 }
 
 class CharCommandArgumentParser : ICommandArgumentParser<Char> {
-    override fun parse(parameter: String): Char? = parameter.firstOrNull()
+    override suspend fun parse(parameter: String): Char? = parameter.firstOrNull()
 }

--- a/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandManager.kt
+++ b/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandManager.kt
@@ -80,7 +80,7 @@ abstract class CommandManager<K : ICommandActor<*>> : ICommandManager<K> {
 
     fun getCommand(input: String): CommandBase? = registeredCommands.firstOrNull { it.isThis(input, false) }
 
-    fun getCompletions(actor: K, input: String): List<String> {
+    suspend fun getCompletions(actor: K, input: String): List<String> {
         val split = input.removeLastSpaces().split(" ")
         if (split.isEmpty()) return emptyList()
         val commandBase = getCommand(input)
@@ -103,7 +103,7 @@ abstract class CommandManager<K : ICommandActor<*>> : ICommandManager<K> {
             .filter { it.isThis(input, commandBase == null) }
     }
 
-    private fun collectSubCommandPaths(actor: K, input: String, possibleCommands: List<CommandBase>): List<String> {
+    private suspend fun collectSubCommandPaths(actor: K, input: String, possibleCommands: List<CommandBase>): List<String> {
         val list = mutableListOf<String>()
         possibleCommands.forEach { command ->
             val possibleSubCommands = command.subCommands
@@ -152,7 +152,7 @@ abstract class CommandManager<K : ICommandActor<*>> : ICommandManager<K> {
             .filter { it.lowercase().startsWith(firstWord.lowercase()) }
     }
 
-    private fun resolveCompletionResults(
+    private suspend fun resolveCompletionResults(
         subCommandPaths: List<String>,
         split: List<String>,
         input: String,
@@ -182,7 +182,7 @@ abstract class CommandManager<K : ICommandActor<*>> : ICommandManager<K> {
         }
     }
 
-    private fun resolvePathResult(
+    private suspend fun resolvePathResult(
         results: MutableSet<String>,
         input: String,
         inputR: String,
@@ -210,7 +210,7 @@ abstract class CommandManager<K : ICommandActor<*>> : ICommandManager<K> {
         }
     }
 
-    private fun collectArgumentSuggestions(
+    private suspend fun collectArgumentSuggestions(
         results: MutableSet<String>,
         input: String,
         inputR: String,

--- a/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandManager.kt
+++ b/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandManager.kt
@@ -232,7 +232,7 @@ abstract class CommandManager<K : ICommandActor<*>> : ICommandManager<K> {
     }
 
     @Suppress("ReturnCount")
-    fun handleInput(actor: K, input: String): CommandResponse {
+    suspend fun handleInput(actor: K, input: String): CommandResponse {
         if (input.isBlank()) return CommandResponse(CommandResponseType.BLANK_INPUT, "Command cannot be blank")
         val split = input.removeLastSpaces().split(" ")
         val commandName = split[0].lowercase()

--- a/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandSubBase.kt
+++ b/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/CommandSubBase.kt
@@ -1,7 +1,6 @@
 package dev.redicloud.commands.api
 
 import dev.redicloud.api.commands.*
-import kotlinx.coroutines.runBlocking
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.findAnnotation
@@ -23,7 +22,6 @@ class CommandSubBase(
 
     init {
         suspend = function.isSuspend
-        if (suspend) throw UnsupportedOperationException("Suspend functions are not supported yet!")
         path = function.findAnnotation<CommandSubPath>()!!.path
         description = function.findAnnotation<CommandDescription>()?.description ?: ""
         suggester = CommandSubPathSuggester(this)
@@ -56,7 +54,7 @@ class CommandSubBase(
     }
 
     @Suppress("ReturnCount")
-    fun execute(actor: ICommandActor<*>, arguments: List<String>): CommandResponse {
+    suspend fun execute(actor: ICommandActor<*>, arguments: List<String>): CommandResponse {
         val parsedArguments = mutableListOf<Any?>()
         val max = this.arguments.count { !it.actorArgument }
         val min = this.arguments.count { it.required && !it.actorArgument }
@@ -118,9 +116,8 @@ class CommandSubBase(
         @Suppress("TooGenericExceptionCaught")
         return try {
             if (suspend) {
-                runBlocking { function.callSuspend(command.commandImpl, *final) } // TODO fix this
+                function.callSuspend(command.commandImpl, *final)
             } else {
-                // function.call(command.commandImpl, *final) //TODO fix this
                 function.javaMethod!!.invoke(command.commandImpl, *final)
             }
             CommandResponse(CommandResponseType.SUCCESS, null)

--- a/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/DefaultCommandSuggesters.kt
+++ b/commands/command-api/src/main/kotlin/dev/redicloud/commands/api/DefaultCommandSuggesters.kt
@@ -10,11 +10,11 @@ val SUGGESTERS = mutableListOf(
 )
 
 class CommandSubPathSuggester(val subCommand: CommandSubBase) : AbstractCommandSuggester() {
-    override fun suggest(context: CommandContext): Array<String> = subCommand.getSubPaths().toTypedArray()
+    override suspend fun suggest(context: CommandContext): Array<String> = subCommand.getSubPaths().toTypedArray()
 }
 
 class CommandSuggester(val command: CommandBase) : AbstractCommandSuggester() {
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         return if (context.input.isEmpty()) {
             arrayOf(command.name)
         } else {
@@ -25,7 +25,7 @@ class CommandSuggester(val command: CommandBase) : AbstractCommandSuggester() {
 
 class CommandArgumentSuggester(val commandArgument: CommandArgument) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         if (!commandArgument.subCommand.isThis(context.input, true)) return arrayOf()
         val nextArgument = commandArgument.isThis(context.input, true)
         if (nextArgument) {

--- a/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/BukkitConnector.kt
+++ b/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/BukkitConnector.kt
@@ -7,7 +7,6 @@ import dev.redicloud.connector.bukkit.provider.BukkitServerPlayerProvider
 import dev.redicloud.service.base.player.BasePlayerExecutor
 import dev.redicloud.service.minecraft.MinecraftServerService
 import dev.redicloud.service.minecraft.provider.AbstractScreenProvider
-import kotlinx.coroutines.runBlocking
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
@@ -25,10 +24,11 @@ class BukkitConnector(val plugin: JavaPlugin) : MinecraftServerService<JavaPlugi
             this.serviceId
         )
 
-    init {
+    override suspend fun start() {
+        super.start()
         initApi()
         registerTasks()
-        runBlocking { moduleHandler.loadModules() }
+        moduleHandler.loadModules()
     }
 
     override fun getConnectorPlugin(): JavaPlugin {

--- a/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/BukkitConnector.kt
+++ b/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/BukkitConnector.kt
@@ -43,7 +43,7 @@ class BukkitConnector(val plugin: JavaPlugin) : MinecraftServerService<JavaPlugi
         super.onDisable()
     }
 
-    override fun plattformShutdown() {
+    override fun platformShutdown() {
         this.bukkitShuttingDown = true
         Bukkit.shutdown()
     }

--- a/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/bootstrap/BukkitConnectorBootstrap.kt
+++ b/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/bootstrap/BukkitConnectorBootstrap.kt
@@ -5,6 +5,7 @@ import dev.redicloud.libloader.boot.Bootstrap
 import dev.redicloud.libloader.boot.loaders.URLClassLoaderJarLoader
 import dev.redicloud.logging.configureLogger
 import dev.redicloud.utils.loadProperties
+import kotlinx.coroutines.runBlocking
 import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 import java.net.URLClassLoader
@@ -23,6 +24,7 @@ class BukkitConnectorBootstrap : JavaPlugin() {
             configureLogger("org.redisson", Level.OFF)
             configureLogger("io.netty", Level.INFO)
             connector = BukkitConnector(this)
+            runBlocking { connector!!.start() }
         } catch (e: Exception) {
             System.err.println("Failed to initialize BukkitConnector: ${e.message}")
             System.err.println(e.stackTraceToString())

--- a/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/player/BukkitPlayerExecutor.kt
+++ b/connectors/bukkit-connector/src/main/kotlin/dev/redicloud/connector/bukkit/player/BukkitPlayerExecutor.kt
@@ -7,10 +7,11 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.server.ICloudServer
 import dev.redicloud.api.service.server.ICloudServerRepository
 import dev.redicloud.service.base.player.BasePlayerExecutor
-import kotlinx.coroutines.runBlocking
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.platform.bukkit.BukkitAudiences
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import org.bukkit.Bukkit
 import org.bukkit.plugin.java.JavaPlugin
 
 class BukkitPlayerExecutor(
@@ -30,11 +31,16 @@ class BukkitPlayerExecutor(
         return _audience!!.player(player.uniqueId)
     }
 
-    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
-        runBlocking { this@BukkitPlayerExecutor.connect(cloudPlayer, server) }
+    override suspend fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        throw UnsupportedOperationException("executeConnect is not supported on a sub server")
     }
 
-    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
-        runBlocking { this@BukkitPlayerExecutor.kick(cloudPlayer, reason) }
+    override suspend fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        val player = Bukkit.getPlayer(cloudPlayer.uniqueId)
+        if (player == null) {
+            LOGGER.warning("Player ${cloudPlayer.uniqueId} not found on this server for kick")
+            return
+        }
+        player.kickPlayer(LegacyComponentSerializer.legacySection().serialize(reason))
     }
 }

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
@@ -101,7 +101,7 @@ class BungeeCordConnector(
         super.onDisable()
     }
 
-    override fun plattformShutdown() {
+    override fun platformShutdown() {
         this.bungeecordShuttingDown = true
         ProxyServer.getInstance().stop()
     }

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
@@ -110,7 +110,7 @@ class BungeeCordConnector(
         fun register(listener: Listener) {
             ProxyServer.getInstance().pluginManager.registerListener(plugin, listener)
         }
-        register(CloudPlayerListener(this.serviceId, this.playerRepository, this.serverRepository, this.plugin))
+        register(CloudPlayerListener(this.serviceId, this.playerRepository, this.serverRepository, this.plugin, this.scope))
     }
 
     override fun getConnectorPlugin(): Plugin {

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
@@ -110,7 +110,9 @@ class BungeeCordConnector(
         fun register(listener: Listener) {
             ProxyServer.getInstance().pluginManager.registerListener(plugin, listener)
         }
-        register(CloudPlayerListener(this.serviceId, this.playerRepository, this.serverRepository, this.plugin, this.scope))
+        register(
+            CloudPlayerListener(this.serviceId, this.playerRepository, this.serverRepository, this.plugin, this.scope)
+        )
     }
 
     override fun getConnectorPlugin(): Plugin {

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/BungeeCordConnector.kt
@@ -39,12 +39,11 @@ class BungeeCordConnector(
         this.eventManager
     )
 
-    init {
+    override suspend fun start() {
+        super.start()
         initApi()
-        runBlocking {
-            registerTasks()
-        }
-        runBlocking { moduleHandler.loadModules() }
+        registerTasks()
+        moduleHandler.loadModules()
     }
 
     override fun registerServer(server: CloudMinecraftServer) {

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/bootstrap/BungeeCordConnectorBootstrap.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/bootstrap/BungeeCordConnectorBootstrap.kt
@@ -4,6 +4,7 @@ import dev.redicloud.connector.bungeecord.BungeeCordConnector
 import dev.redicloud.libloader.boot.Bootstrap
 import dev.redicloud.libloader.boot.loaders.URLClassLoaderJarLoader
 import dev.redicloud.utils.loadProperties
+import kotlinx.coroutines.runBlocking
 import net.md_5.bungee.api.ProxyServer
 import net.md_5.bungee.api.plugin.Plugin
 import java.net.URLClassLoader
@@ -19,6 +20,7 @@ class BungeeCordConnectorBootstrap : Plugin() {
             loadProperties(this.javaClass.classLoader)
             Bootstrap().apply(URLClassLoaderJarLoader(this.javaClass.classLoader as URLClassLoader))
             connector = BungeeCordConnector(this)
+            runBlocking { connector!!.start() }
         } catch (e: Exception) {
             System.err.println("Failed to initialize BungeeCordConnector: ${e.message}")
             System.err.println(e.stackTraceToString())

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/listener/CloudPlayerListener.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/listener/CloudPlayerListener.kt
@@ -131,7 +131,7 @@ class CloudPlayerListener(
             event.kickedFrom.name,
             ServiceType.MINECRAFT_SERVER
         )
-        val fallback = runBlocking { serverRepository.getFallback(cloudPlayer?.serverId, kickedFromServer?.serviceId) }
+        val fallback = serverRepository.getFallback(cloudPlayer?.serverId, kickedFromServer?.serviceId)
         if (fallback == null) {
             event.isCancelled = true
             event.kickReasonComponent = ComponentBuilder().append("You were kicked from the server and no fallback was found!").create()

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/listener/CloudPlayerListener.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/listener/CloudPlayerListener.kt
@@ -5,7 +5,7 @@ import dev.redicloud.api.service.ServiceType
 import dev.redicloud.repository.player.PlayerRepository
 import dev.redicloud.repository.server.CloudMinecraftServer
 import dev.redicloud.repository.server.ServerRepository
-import dev.redicloud.utils.defaultScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import net.md_5.bungee.api.ProxyServer
@@ -24,13 +24,14 @@ class CloudPlayerListener(
     private val serviceId: ServiceId,
     private val playerRepository: PlayerRepository,
     private val serverRepository: ServerRepository,
-    private val plugin: Plugin
+    private val plugin: Plugin,
+    private val scope: CoroutineScope
 ) : Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     fun onLogin(event: LoginEvent) {
         event.registerIntent(plugin)
-        defaultScope.launch {
+        scope.launch {
             try {
                 val fallback = serverRepository.getFallback()
                 if (fallback == null) {

--- a/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/player/BungeeCordPlayerExecutor.kt
+++ b/connectors/bungeecord-connector/src/main/kotlin/dev/redicloud/connector/bungeecord/player/BungeeCordPlayerExecutor.kt
@@ -7,7 +7,6 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.server.ICloudServer
 import dev.redicloud.api.service.server.ICloudServerRepository
 import dev.redicloud.service.base.player.BasePlayerExecutor
-import kotlinx.coroutines.runBlocking
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences
 import net.kyori.adventure.text.Component
@@ -32,20 +31,20 @@ class BungeeCordPlayerExecutor(
         return audiences!!.player(player.uniqueId)
     }
 
-    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+    override suspend fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
         val player = ProxyServer.getInstance().getPlayer(cloudPlayer.uniqueId)
         if (player == null || !player.isConnected) {
-            runBlocking { this@BungeeCordPlayerExecutor.connect(cloudPlayer, server) }
+            LOGGER.warning("Player ${cloudPlayer.uniqueId} not found on this proxy despite proxyId matching")
             return
         }
         val serverInfo = ProxyServer.getInstance().getServerInfo(server.name) ?: return
         player.connect(serverInfo)
     }
 
-    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+    override suspend fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
         val player = ProxyServer.getInstance().getPlayer(cloudPlayer.uniqueId)
         if (player == null || !player.isConnected) {
-            runBlocking { this@BungeeCordPlayerExecutor.executeKick(cloudPlayer, reason) }
+            LOGGER.warning("Player ${cloudPlayer.uniqueId} not found on this proxy despite proxyId matching")
             return
         }
         val components = BungeeComponentSerializer.get().serialize(reason)

--- a/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/MinestomConnector.kt
+++ b/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/MinestomConnector.kt
@@ -7,7 +7,6 @@ import dev.redicloud.connector.minestom.provider.MinestomServerPlayerProvider
 import dev.redicloud.service.base.player.BasePlayerExecutor
 import dev.redicloud.service.minecraft.MinecraftServerService
 import dev.redicloud.service.minecraft.provider.AbstractScreenProvider
-import kotlinx.coroutines.runBlocking
 import net.minestom.server.MinecraftServer
 import net.minestom.server.extensions.Extension
 
@@ -21,10 +20,11 @@ class MinestomConnector(val extension: Extension) : MinecraftServerService<Exten
     override val playerExecutor: BasePlayerExecutor =
         MinestomPlayerExecutor(this.playerRepository, this.serverRepository, this.packetManager, this.serviceId)
 
-    init {
+    override suspend fun start() {
+        super.start()
         initApi()
         registerTasks()
-        runBlocking { moduleHandler.loadModules() }
+        moduleHandler.loadModules()
     }
 
     override fun onDisable() {

--- a/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/MinestomConnector.kt
+++ b/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/MinestomConnector.kt
@@ -35,7 +35,7 @@ class MinestomConnector(val extension: Extension) : MinecraftServerService<Exten
         super.onDisable()
     }
 
-    override fun plattformShutdown() {
+    override fun platformShutdown() {
         this.minestomShuttingDown = true
         MinecraftServer.stopCleanly()
     }

--- a/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/bootstrap/MinestomConnectorBootstrap.kt
+++ b/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/bootstrap/MinestomConnectorBootstrap.kt
@@ -5,6 +5,7 @@ import dev.redicloud.libloader.boot.Bootstrap
 import dev.redicloud.libloader.boot.apply.impl.JarResourceLoader
 import dev.redicloud.logging.configureLogger
 import dev.redicloud.utils.loadProperties
+import kotlinx.coroutines.runBlocking
 import net.minestom.server.MinecraftServer
 import net.minestom.server.extensions.Extension
 import net.minestom.server.extensions.ExtensionClassLoader
@@ -27,6 +28,7 @@ class MinestomConnectorBootstrap : Extension() {
             configureLogger("org.redisson", Level.OFF)
             configureLogger("io.netty", Level.INFO)
             connector = MinestomConnector(this)
+            runBlocking { connector!!.start() }
         } catch (e: Exception) {
             System.err.println("Failed to initialize MinestomConnector: ${e.message}")
             System.err.println(e.stackTraceToString())

--- a/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/player/MinestomPlayerExecutor.kt
+++ b/connectors/minestom-connector/src/main/kotlin/dev/redicloud/connector/minestom/player/MinestomPlayerExecutor.kt
@@ -7,7 +7,6 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.server.ICloudServer
 import dev.redicloud.api.service.server.ICloudServerRepository
 import dev.redicloud.service.base.player.BasePlayerExecutor
-import kotlinx.coroutines.runBlocking
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import net.minestom.server.MinecraftServer
@@ -25,11 +24,16 @@ class MinestomPlayerExecutor(
         return Audiences.players { it.uuid == minestomPlayer.uuid }
     }
 
-    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
-        runBlocking { this@MinestomPlayerExecutor.connect(cloudPlayer, server) }
+    override suspend fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        throw UnsupportedOperationException("executeConnect is not supported on a sub server")
     }
 
-    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
-        runBlocking { this@MinestomPlayerExecutor.executeKick(cloudPlayer, reason) }
+    override suspend fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        val player = MinecraftServer.getConnectionManager().getOnlinePlayerByUuid(cloudPlayer.uniqueId)
+        if (player == null) {
+            LOGGER.warning("Player ${cloudPlayer.uniqueId} not found on this server for kick")
+            return
+        }
+        player.kick(reason)
     }
 }

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
@@ -109,7 +109,7 @@ class VelocityConnector(
     private fun registerListeners() {
         this.proxyServer.eventManager.register(
             getConnectorPlugin(),
-            CloudPlayerListener(this.serviceId, this.playerRepository, this.serverRepository, this.proxyServer)
+            CloudPlayerListener(this.serviceId, this.playerRepository, this.serverRepository, this.proxyServer, this.scope)
         )
     }
 

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
@@ -109,7 +109,13 @@ class VelocityConnector(
     private fun registerListeners() {
         this.proxyServer.eventManager.register(
             getConnectorPlugin(),
-            CloudPlayerListener(this.serviceId, this.playerRepository, this.serverRepository, this.proxyServer, this.scope)
+            CloudPlayerListener(
+                this.serviceId,
+                this.playerRepository,
+                this.serverRepository,
+                this.proxyServer,
+                this.scope
+            )
         )
     }
 

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
@@ -101,7 +101,7 @@ class VelocityConnector(
         super.onDisable()
     }
 
-    override fun plattformShutdown() {
+    override fun platformShutdown() {
         this.velocityShuttingDown = true
         this.proxyServer.shutdown()
     }

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/VelocityConnector.kt
@@ -36,13 +36,12 @@ class VelocityConnector(
     override val notificationListeners: AbstractCloudNotificationListeners =
         CloudNotificationListeners(this.proxyServer, this.serverRepository, this.nodeRepository, this.eventManager)
 
-    init {
+    override suspend fun start() {
+        super.start()
         initApi()
-        runBlocking {
-            registerTasks()
-            registerStartedServers()
-        }
-        runBlocking { moduleHandler.loadModules() }
+        registerTasks()
+        registerStartedServers()
+        moduleHandler.loadModules()
     }
 
     override fun registerServer(server: CloudMinecraftServer) {

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/bootstrap/VelocityConnectorBootstrap.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/bootstrap/VelocityConnectorBootstrap.kt
@@ -11,6 +11,7 @@ import dev.redicloud.connector.velocity.VelocityConnector
 import dev.redicloud.libloader.boot.Bootstrap
 import dev.redicloud.libloader.boot.loaders.URLClassLoaderJarLoader
 import dev.redicloud.utils.loadProperties
+import kotlinx.coroutines.runBlocking
 import java.net.URLClassLoader
 import java.util.logging.Logger
 import kotlin.system.exitProcess
@@ -32,6 +33,7 @@ class VelocityConnectorBootstrap @Inject constructor(val proxyServer: ProxyServe
             loadProperties(this.javaClass.classLoader)
             Bootstrap().apply(URLClassLoaderJarLoader(this.javaClass.classLoader as URLClassLoader))
             connector = VelocityConnector(proxyServer)
+            runBlocking { connector!!.start() }
         } catch (e: Exception) {
             System.err.println("Failed to initialize VelocityConnector: ${e.message}")
             System.err.println(e.stackTraceToString())

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/listener/CloudPlayerListener.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/listener/CloudPlayerListener.kt
@@ -1,5 +1,6 @@
 package dev.redicloud.connector.velocity.listener
 
+import com.velocitypowered.api.event.EventTask
 import com.velocitypowered.api.event.PostOrder
 import com.velocitypowered.api.event.Subscribe
 import com.velocitypowered.api.event.connection.DisconnectEvent
@@ -14,7 +15,8 @@ import dev.redicloud.repository.player.CloudPlayer
 import dev.redicloud.repository.player.PlayerRepository
 import dev.redicloud.repository.server.CloudMinecraftServer
 import dev.redicloud.repository.server.ServerRepository
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import net.kyori.adventure.text.Component
 import kotlin.jvm.optionals.getOrElse
 
@@ -22,15 +24,28 @@ class CloudPlayerListener(
     private val serviceId: ServiceId,
     private val playerRepository: PlayerRepository,
     private val serverRepository: ServerRepository,
-    private val proxyServer: ProxyServer
+    private val proxyServer: ProxyServer,
+    private val scope: CoroutineScope
 ) {
 
+    private fun suspendEvent(block: suspend () -> Unit): EventTask {
+        return EventTask.withContinuation { continuation ->
+            scope.launch {
+                try {
+                    block()
+                } finally {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
     @Subscribe(order = PostOrder.FIRST)
-    fun onPostLogin(event: PostLoginEvent) = runBlocking {
+    fun onPostLogin(event: PostLoginEvent) = suspendEvent {
         val fallback = serverRepository.getFallback()
         if (fallback == null) {
             event.player.disconnect(Component.text("No fallback server found!"))
-            return@runBlocking
+            return@suspendEvent
         }
         val player = event.player
         if (playerRepository.existsPlayer(player.uniqueId)) {
@@ -39,7 +54,7 @@ class CloudPlayerListener(
                 (cloudPlayer.proxyId == serviceId && event.player.currentServer.isPresent)
             if (cloudPlayer.connected && alreadyConnected) {
                 event.player.disconnect(Component.text("You are already connected to the network!"))
-                return@runBlocking
+                return@suspendEvent
             }
             cloudPlayer.connected = true
             cloudPlayer.lastConnect = System.currentTimeMillis()
@@ -64,9 +79,9 @@ class CloudPlayerListener(
     }
 
     @Subscribe(order = PostOrder.LAST)
-    fun onDisconnect(event: DisconnectEvent) = runBlocking {
+    fun onDisconnect(event: DisconnectEvent) = suspendEvent {
         val player = event.player
-        val cloudPlayer = playerRepository.getPlayer(player.uniqueId) ?: return@runBlocking
+        val cloudPlayer = playerRepository.getPlayer(player.uniqueId) ?: return@suspendEvent
         cloudPlayer.lastDisconnect = System.currentTimeMillis()
         cloudPlayer.proxyId = null
         cloudPlayer.serverId = null
@@ -75,8 +90,8 @@ class CloudPlayerListener(
     }
 
     @Subscribe
-    fun onServerPreConnect(event: ServerPreConnectEvent) = runBlocking {
-        if (!event.result.isAllowed) return@runBlocking
+    fun onServerPreConnect(event: ServerPreConnectEvent) = suspendEvent {
+        if (!event.result.isAllowed) return@suspendEvent
         val targetServer = if (event.originalServer.serverInfo.name == "rcfallback") {
             serverRepository.getFallback()
         } else {
@@ -84,18 +99,18 @@ class CloudPlayerListener(
         }
         if (targetServer == null) {
             event.player.disconnect(Component.text("No fallback server found!"))
-            return@runBlocking
+            return@suspendEvent
         }
         val server = proxyServer.getServer(targetServer.name)
         if (!server.isPresent) {
             event.player.disconnect(Component.text("No fallback server found!"))
-            return@runBlocking
+            return@suspendEvent
         }
         event.result = ServerPreConnectEvent.ServerResult.allowed(server.get())
     }
 
     @Subscribe(order = PostOrder.FIRST)
-    fun onServerConnected(event: ServerConnectedEvent): Unit = runBlocking {
+    fun onServerConnected(event: ServerConnectedEvent) = suspendEvent {
         val player = event.player
         val cloudPlayer = playerRepository.getPlayer(player.uniqueId)
         if (cloudPlayer == null) {
@@ -107,7 +122,7 @@ class CloudPlayerListener(
     }
 
     @Subscribe(order = PostOrder.FIRST)
-    fun onKickedFromServer(event: KickedFromServerEvent) = runBlocking {
+    fun onKickedFromServer(event: KickedFromServerEvent) = suspendEvent {
         val player = event.player
         val cloudPlayer = playerRepository.getPlayer(player.uniqueId)
         if (cloudPlayer != null) {
@@ -128,7 +143,7 @@ class CloudPlayerListener(
                     Component.text("You were kicked from the server and no fallback was found!")
                 }
             )
-            return@runBlocking
+            return@suspendEvent
         }
         val server = proxyServer.getServer(fallback.name)
         if (!server.isPresent) {
@@ -137,7 +152,7 @@ class CloudPlayerListener(
                     Component.text("You were kicked from the server and no fallback was found!")
                 }
             )
-            return@runBlocking
+            return@suspendEvent
         }
         if (event.server.serverInfo.name == server.get().serverInfo.name) {
             event.result = KickedFromServerEvent.DisconnectPlayer.create(
@@ -145,7 +160,7 @@ class CloudPlayerListener(
                     Component.text("You were kicked from the server and no fallback was found!")
                 }
             )
-            return@runBlocking
+            return@suspendEvent
         }
         event.result = KickedFromServerEvent.RedirectPlayer.create(server.get())
     }

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/listener/CloudPlayerListener.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/listener/CloudPlayerListener.kt
@@ -27,7 +27,7 @@ class CloudPlayerListener(
 
     @Subscribe(order = PostOrder.FIRST)
     fun onPostLogin(event: PostLoginEvent) = runBlocking {
-        val fallback = runBlocking { serverRepository.getFallback() }
+        val fallback = serverRepository.getFallback()
         if (fallback == null) {
             event.player.disconnect(Component.text("No fallback server found!"))
             return@runBlocking
@@ -121,7 +121,7 @@ class CloudPlayerListener(
             event.server.serverInfo.name,
             ServiceType.MINECRAFT_SERVER
         )
-        val fallback = runBlocking { serverRepository.getFallback(cloudPlayer?.serverId, kickedFromServer?.serviceId) }
+        val fallback = serverRepository.getFallback(cloudPlayer?.serverId, kickedFromServer?.serviceId)
         if (fallback == null) {
             event.result = KickedFromServerEvent.DisconnectPlayer.create(
                 event.serverKickReason.getOrElse {

--- a/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/player/VelocityPlayerExecutor.kt
+++ b/connectors/velocity-connector/src/main/kotlin/dev/redicloud/connector/velocity/player/VelocityPlayerExecutor.kt
@@ -8,7 +8,6 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.server.ICloudServer
 import dev.redicloud.api.service.server.ICloudServerRepository
 import dev.redicloud.service.base.player.BasePlayerExecutor
-import kotlinx.coroutines.runBlocking
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import kotlin.jvm.optionals.getOrNull
@@ -25,20 +24,20 @@ class VelocityPlayerExecutor(
         return proxyServer.getPlayer(player.uniqueId).getOrNull()!!
     }
 
-    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+    override suspend fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
         val player = proxyServer.getPlayer(cloudPlayer.uniqueId).getOrNull()
         if (player == null || !player.isActive) {
-            runBlocking { this@VelocityPlayerExecutor.connect(cloudPlayer, server) }
+            LOGGER.warning("Player ${cloudPlayer.uniqueId} not found on this proxy despite proxyId matching")
             return
         }
         val serverInfo = proxyServer.getServer(server.name).getOrNull() ?: return
         player.createConnectionRequest(serverInfo).fireAndForget()
     }
 
-    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+    override suspend fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
         val player = proxyServer.getPlayer(cloudPlayer.uniqueId).getOrNull()
         if (player == null || !player.isActive) {
-            runBlocking { this@VelocityPlayerExecutor.kick(cloudPlayer, reason) }
+            LOGGER.warning("Player ${cloudPlayer.uniqueId} not found on this proxy despite proxyId matching")
             return
         }
         player.disconnect(reason)

--- a/console/src/main/kotlin/dev/redicloud/console/Console.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/Console.kt
@@ -232,7 +232,7 @@ open class Console(
         val commandManager = CURRENT_CONSOLE?.commandManager ?: return
         @Suppress("TooGenericExceptionCaught")
         try {
-            val response = commandManager.handleInput(commandManager.defaultActor, line)
+            val response = runBlocking { commandManager.handleInput(commandManager.defaultActor, line) }
             if (response.type == CommandResponseType.HELP_SENT) return
             if (response.message != null && response.type != CommandResponseType.BLANK_INPUT &&
                 response.type != CommandResponseType.ERROR

--- a/console/src/main/kotlin/dev/redicloud/console/Console.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/Console.kt
@@ -106,6 +106,7 @@ open class Console(
     override var matchingHistorySearch = true
 
     private val animationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + coroutineExceptionHandler)
+    var commandScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + coroutineExceptionHandler)
     private var logRecordDispatcher: ThreadRecordDispatcher? = null
 
     init {
@@ -230,20 +231,22 @@ open class Console(
     private fun handleCommandInput(line: String) {
         if (CURRENT_CONSOLE?.commandManager?.areCommandsDisabled() != false) return
         val commandManager = CURRENT_CONSOLE?.commandManager ?: return
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val response = runBlocking { commandManager.handleInput(commandManager.defaultActor, line) }
-            if (response.type == CommandResponseType.HELP_SENT) return
-            if (response.message != null && response.type != CommandResponseType.BLANK_INPUT &&
-                response.type != CommandResponseType.ERROR
-            ) {
-                commandManager.defaultActor.sendMessage(response.message!!)
+        commandScope.launch {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val response = commandManager.handleInput(commandManager.defaultActor, line)
+                if (response.type == CommandResponseType.HELP_SENT) return@launch
+                if (response.message != null && response.type != CommandResponseType.BLANK_INPUT &&
+                    response.type != CommandResponseType.ERROR
+                ) {
+                    commandManager.defaultActor.sendMessage(response.message!!)
+                }
+                if (response.throwable != null && response.type == CommandResponseType.ERROR) {
+                    LOGGER.severe(response.message!!, response.throwable!!)
+                }
+            } catch (e: Exception) {
+                LOGGER.severe("Error while routing/processing command", e)
             }
-            if (response.throwable != null && response.type == CommandResponseType.ERROR) {
-                LOGGER.severe(response.message!!, response.throwable!!)
-            }
-        } catch (e: Exception) {
-            LOGGER.severe("Error while routing/processing command", e)
         }
     }
 
@@ -360,7 +363,7 @@ open class Console(
 
     override fun getScreens(): List<Screen> = screens.toList()
 
-    override fun getScreen(name: String): Screen? = screens.firstOrNull { it.name.lowercase() == name.lowercase() }
+    override fun getScreen(name: String): Screen? = screens.firstOrNull { it.name.equals(name, ignoreCase = true) }
 
     override fun createScreen(
         name: String,

--- a/console/src/main/kotlin/dev/redicloud/console/Console.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/Console.kt
@@ -37,6 +37,7 @@ import dev.redicloud.utils.coroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -103,7 +104,7 @@ open class Console(
     override var printingEnabled = true
     override var matchingHistorySearch = true
 
-    private val animationScope = CoroutineScope(Dispatchers.Default + coroutineExceptionHandler)
+    private val animationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + coroutineExceptionHandler)
     private var logRecordDispatcher: ThreadRecordDispatcher? = null
 
     init {

--- a/console/src/main/kotlin/dev/redicloud/console/Console.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/Console.kt
@@ -54,6 +54,7 @@ import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
@@ -320,8 +321,8 @@ open class Console(
 
     override fun startAnimation(animation: AbstractConsoleAnimation) {
         val uniqueId = UUID.randomUUID()
-        var started = false
-        animation.addStartHandler { started = true }
+        val latch = CountDownLatch(1)
+        animation.addStartHandler { latch.countDown() }
         val job = animationScope.launch {
             animation.running = true
             animation.run()
@@ -330,7 +331,7 @@ open class Console(
             animation.handleDone()
         }
         runningAnimations[uniqueId] = job to animation
-        while (!started) Thread.sleep(10)
+        latch.await()
     }
 
     override fun cancelAnimations() {

--- a/console/src/main/kotlin/dev/redicloud/console/Console.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/Console.kt
@@ -201,7 +201,7 @@ open class Console(
 
     private fun run() {
         CONSOLE_THREAD = Thread({
-            CURRENT_CONSOLE?.eventManager?.fireEvent(ConsoleRunEvent(this@Console))
+            runBlocking { CURRENT_CONSOLE?.eventManager?.fireEvent(ConsoleRunEvent(this@Console)) }
             while (!Thread.currentThread().isInterrupted) {
                 val line = readLineInput() ?: continue
                 CURRENT_CONSOLE?.defaultScreen?.addLine((CURRENT_CONSOLE?.prompt ?: "") + line + "\r\n")

--- a/console/src/main/kotlin/dev/redicloud/console/animation/AbstractConsoleAnimation.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/animation/AbstractConsoleAnimation.kt
@@ -1,14 +1,18 @@
 package dev.redicloud.console.animation
 
 import dev.redicloud.console.Console
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import org.fusesource.jansi.Ansi
 import java.time.Instant
+import kotlin.time.Duration.Companion.milliseconds
 
 abstract class AbstractConsoleAnimation(
     val updateInterval: Long,
     val staticCursor: Boolean,
     val console: Console
-) : Runnable {
+) {
 
     protected val finishHandlers: MutableList<() -> Unit> = mutableListOf()
     protected val startHandlers: MutableList<() -> Unit> = mutableListOf()
@@ -42,19 +46,15 @@ abstract class AbstractConsoleAnimation(
 
     protected abstract fun handleTick(): Boolean
 
-    override fun run() {
+    suspend fun run() {
         this.startInstant = Instant.now()
         this.console.forceWriteLine(System.lineSeparator())
         var first = false
-        while (!Thread.currentThread().isInterrupted && !this.handleTick() && running) {
+        while (!this.handleTick() && running) {
+            currentCoroutineContext().ensureActive()
             if (!first) this.startHandlers.forEach { it() }
             first = true
-            try {
-                Thread.sleep(this.updateInterval)
-            } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
-                break
-            }
+            delay(this.updateInterval.milliseconds)
         }
     }
 

--- a/console/src/main/kotlin/dev/redicloud/console/jline/ConsoleCompleter.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/jline/ConsoleCompleter.kt
@@ -1,6 +1,7 @@
 package dev.redicloud.console.jline
 
 import dev.redicloud.console.Console
+import kotlinx.coroutines.runBlocking
 import org.jline.reader.Candidate
 import org.jline.reader.Completer
 import org.jline.reader.LineReader
@@ -20,10 +21,12 @@ class ConsoleCompleter(val console: Console) : Completer {
         }
 
         candidates.addAll(
-            console.commandManager.getCompletions(
-                console.commandManager.defaultActor,
-                line.line()
-            ).map { Candidate(it) }
+            runBlocking {
+                console.commandManager.getCompletions(
+                    console.commandManager.defaultActor,
+                    line.line()
+                )
+            }.map { Candidate(it) }
         )
     }
 }

--- a/console/src/main/kotlin/dev/redicloud/console/jline/ConsoleInputReader.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/jline/ConsoleInputReader.kt
@@ -1,28 +1,14 @@
 package dev.redicloud.console.jline
 
-import dev.redicloud.logging.LogManager
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.CompletableDeferred
 
 class ConsoleInputReader {
 
-    companion object {
-        private val LOGGER = LogManager.logger(ConsoleInputReader::class.java)
-        private const val INPUT_POLL_INTERVAL_MS = 500L
-    }
+    private val deferred = CompletableDeferred<String>()
 
-    private var input: String? = null
-    suspend fun readNextInput(): String {
-        while (input == null) {
-            try {
-                delay(INPUT_POLL_INTERVAL_MS)
-            } catch (e: InterruptedException) {
-                LOGGER.severe("Interrupted while waiting for input", e)
-                return ""
-            }
-        }
-        return this.input!!
-    }
+    suspend fun readNextInput(): String = deferred.await()
+
     fun acceptInput(input: String) {
-        this.input = input
+        deferred.complete(input)
     }
 }

--- a/console/src/main/kotlin/dev/redicloud/console/utils/Screen.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/utils/Screen.kt
@@ -4,6 +4,7 @@ import dev.redicloud.api.commands.IRegisteredCommand
 import dev.redicloud.console.Console
 import dev.redicloud.console.events.screen.ScreenChangedEvent
 import dev.redicloud.utils.History
+import kotlinx.coroutines.runBlocking
 
 open class Screen(
     val console: Console,
@@ -33,7 +34,7 @@ open class Screen(
             if (!isCommandAllowed(it)) console.commandManager.disableCommand(it)
         }
         console.clearScreen()
-        console.eventManager?.fireEvent(ScreenChangedEvent(console, this, oldScreen))
+        runBlocking { console.eventManager?.fireEvent(ScreenChangedEvent(console, this@Screen, oldScreen)) }
         history.forEach { console.writeRaw(it, printDirectly = true) }
         if (storeMessages) {
             queuedMessage.forEach {

--- a/console/src/main/kotlin/dev/redicloud/console/utils/ScreenParser.kt
+++ b/console/src/main/kotlin/dev/redicloud/console/utils/ScreenParser.kt
@@ -5,7 +5,7 @@ import dev.redicloud.console.Console
 
 class ScreenParser(private val console: Console) : ICommandArgumentParser<Screen> {
 
-    override fun parse(parameter: String): Screen? {
-        return console.getScreens().firstOrNull { it.name.lowercase() == parameter.lowercase() }
+    override suspend fun parse(parameter: String): Screen? {
+        return console.getScreens().firstOrNull { it.name.equals(parameter, ignoreCase = true) }
     }
 }

--- a/events/src/main/kotlin/dev/redicloud/event/CloudEventPacket.kt
+++ b/events/src/main/kotlin/dev/redicloud/event/CloudEventPacket.kt
@@ -4,6 +4,7 @@ import dev.redicloud.api.events.CloudEvent
 import dev.redicloud.api.packets.AbstractPacket
 import dev.redicloud.api.packets.IPacketManager
 import dev.redicloud.utils.gson.gson
+import kotlinx.coroutines.runBlocking
 
 class CloudEventPacket(
     val eventData: String,
@@ -23,7 +24,7 @@ class CloudEventPacket(
         try {
             val clazz = Class.forName(eventClazz)
             val event = gson.fromJson(eventData, clazz) as CloudEvent
-            eventManager.fireLocalEvent(event)
+            runBlocking { eventManager.fireLocalEvent(event) }
         } catch (e: ClassNotFoundException) {
             EventManager.LOGGER.severe("Error while parsing packet called event $eventClazz", e)
             return

--- a/events/src/main/kotlin/dev/redicloud/event/CloudEventPacket.kt
+++ b/events/src/main/kotlin/dev/redicloud/event/CloudEventPacket.kt
@@ -4,7 +4,6 @@ import dev.redicloud.api.events.CloudEvent
 import dev.redicloud.api.packets.AbstractPacket
 import dev.redicloud.api.packets.IPacketManager
 import dev.redicloud.utils.gson.gson
-import kotlinx.coroutines.runBlocking
 
 class CloudEventPacket(
     val eventData: String,
@@ -12,7 +11,7 @@ class CloudEventPacket(
     val managerIdentifier: String
 ) : AbstractPacket() {
 
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         val eventManager = EventManager.getManager(managerIdentifier)
         if (eventManager == null) {
@@ -24,7 +23,7 @@ class CloudEventPacket(
         try {
             val clazz = Class.forName(eventClazz)
             val event = gson.fromJson(eventData, clazz) as CloudEvent
-            runBlocking { eventManager.fireLocalEvent(event) }
+            eventManager.fireLocalEvent(event)
         } catch (e: ClassNotFoundException) {
             EventManager.LOGGER.severe("Error while parsing packet called event $eventClazz", e)
             return

--- a/events/src/main/kotlin/dev/redicloud/event/EventManager.kt
+++ b/events/src/main/kotlin/dev/redicloud/event/EventManager.kt
@@ -39,13 +39,10 @@ class EventManager(
     }
 
     fun unregister(classLoader: ClassLoader) {
-        lock.lock()
-        try {
+        lock.withLock {
             handlers.values.forEach { list ->
                 list.removeIf { it.listener::class.java.classLoader == classLoader }
             }
-        } finally {
-            lock.unlock()
         }
     }
 
@@ -72,13 +69,10 @@ class EventManager(
     }
 
     override fun unregisterListener(listener: Any) {
-        lock.lock()
-        try {
+        lock.withLock {
             handlers.values.forEach { list ->
                 list.removeIf { it.listener == listener }
             }
-        } finally {
-            lock.unlock()
         }
     }
 

--- a/events/src/main/kotlin/dev/redicloud/event/EventManager.kt
+++ b/events/src/main/kotlin/dev/redicloud/event/EventManager.kt
@@ -9,10 +9,10 @@ import dev.redicloud.api.service.ServiceType
 import dev.redicloud.logging.LogManager
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.utils.gson.gson
-import kotlinx.coroutines.runBlocking
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.reflect.KClass
+import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.full.findAnnotation
 
@@ -50,37 +50,24 @@ class EventManager(
     }
 
     override fun registerListener(listener: Any) {
-        val objClass = listener::class
-        objClass.declaredMemberFunctions.forEach { function ->
-            val annotation = function.findAnnotation<CloudEventListener>()
-            if (annotation != null) {
-                val eventType = function.parameters.first().type.classifier as KClass<*>
-                val handlerMethod = EventHandlerMethod(listener, function, annotation.priority)
-                lock.lock()
-                try {
-                    handlers.getOrPut(eventType) { mutableListOf() }.add(handlerMethod)
-                    handlers[eventType]?.sortWith(compareByDescending<EventHandlerMethod> { it.priority })
-                } finally {
-                    lock.unlock()
-                }
-            }
+        listener::class.declaredMemberFunctions.forEach { function ->
+            val annotation = function.findAnnotation<CloudEventListener>() ?: return@forEach
+            val eventType = function.parameters.first().type.classifier as KClass<*>
+            registerHandler(eventType, EventHandlerMethod(listener, function, annotation.priority))
         }
     }
 
     override fun registerInlineListener(listener: InlineEventCaller<*>) {
         InlineEventCaller::class.declaredMemberFunctions.forEach { function ->
-            val annotation = function.findAnnotation<CloudEventListener>()
-            if (annotation != null) {
-                val eventType = listener.eventClass
-                val handlerMethod = EventHandlerMethod(listener, function, annotation.priority)
-                lock.lock()
-                try {
-                    handlers.getOrPut(eventType) { mutableListOf() }.add(handlerMethod)
-                    handlers[eventType]?.sortWith(compareByDescending<EventHandlerMethod> { it.priority })
-                } finally {
-                    lock.unlock()
-                }
-            }
+            val annotation = function.findAnnotation<CloudEventListener>() ?: return@forEach
+            registerHandler(listener.eventClass, EventHandlerMethod(listener, function, annotation.priority))
+        }
+    }
+
+    private fun registerHandler(eventType: KClass<*>, handlerMethod: EventHandlerMethod) {
+        lock.withLock {
+            handlers.getOrPut(eventType) { mutableListOf() }.add(handlerMethod)
+            handlers[eventType]?.sortWith(compareByDescending { it.priority })
         }
     }
 
@@ -95,7 +82,7 @@ class EventManager(
         }
     }
 
-    override fun fireEvent(event: CloudEvent) {
+    override suspend fun fireEvent(event: CloudEvent) {
         LOGGER.finest("Firing event ${event::class.simpleName} with fire type ${event.fireType}")
         when (event.fireType) {
             EventFireType.GLOBAL -> publishEventBroadcast(event)
@@ -117,36 +104,32 @@ class EventManager(
         }
     }
 
-    private fun publishEventBroadcast(event: CloudEvent) {
-        runBlocking {
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                packetManager?.publishBroadcast(createEventPacket(event))
-                fireLocalEvent(event)
-            } catch (e: Exception) {
-                LOGGER.severe(
-                    "Error while publishing global event (Make sure ${event::class.simpleName} is serializable)",
-                    e
-                )
-            }
+    private suspend fun publishEventBroadcast(event: CloudEvent) {
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            packetManager?.publishBroadcast(createEventPacket(event))
+            fireLocalEvent(event)
+        } catch (e: Exception) {
+            LOGGER.severe(
+                "Error while publishing global event (Make sure ${event::class.simpleName} is serializable)",
+                e
+            )
         }
     }
 
-    private fun publishEventToServices(event: CloudEvent, description: String, vararg serviceTypes: ServiceType) {
-        runBlocking {
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                val packet = createEventPacket(event)
-                serviceTypes.forEach { serviceType ->
-                    packetManager?.publish(packet, serviceType)
-                }
-                fireLocalEvent(event)
-            } catch (e: Exception) {
-                LOGGER.severe(
-                    "Error while publishing $description event (Make sure ${event::class.simpleName} is serializable)",
-                    e
-                )
+    private suspend fun publishEventToServices(event: CloudEvent, description: String, vararg serviceTypes: ServiceType) {
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            val packet = createEventPacket(event)
+            serviceTypes.forEach { serviceType ->
+                packetManager?.publish(packet, serviceType)
             }
+            fireLocalEvent(event)
+        } catch (e: Exception) {
+            LOGGER.severe(
+                "Error while publishing $description event (Make sure ${event::class.simpleName} is serializable)",
+                e
+            )
         }
     }
 
@@ -158,16 +141,19 @@ class EventManager(
         )
     }
 
-    internal fun fireLocalEvent(event: CloudEvent) {
+    internal suspend fun fireLocalEvent(event: CloudEvent) {
         val eventType = event::class
-        lock.withLock {
-            handlers[eventType]?.forEach { handlerMethod ->
-                @Suppress("TooGenericExceptionCaught")
-                try {
+        val handlersCopy = lock.withLock { handlers[eventType]?.toList() } ?: return
+        handlersCopy.forEach { handlerMethod ->
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                if (handlerMethod.function.isSuspend) {
+                    handlerMethod.function.callSuspend(handlerMethod.listener, event)
+                } else {
                     handlerMethod.function.call(handlerMethod.listener, event)
-                } catch (e: Exception) {
-                    LOGGER.severe("Error while calling event handler", e)
                 }
+            } catch (e: Exception) {
+                LOGGER.severe("Error while calling event handler", e)
             }
         }
     }

--- a/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/FileCluster.kt
+++ b/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/FileCluster.kt
@@ -19,8 +19,10 @@ import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.node.NodeRepository
 import dev.redicloud.utils.findFreePort
 import dev.redicloud.utils.isPortFree
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory
 import org.apache.sshd.common.util.net.SshdSocketAddress
 import org.apache.sshd.server.SshServer
@@ -178,14 +180,14 @@ class FileCluster(
         session.setPassword(fileNode.password)
         session.setConfig("serviceId", serviceId.toName())
         session.setConfig("StrictHostKeyChecking", "no")
-        session.connect()
+        withContext(Dispatchers.IO) { session.connect() }
         check(session.isConnected) { "Session is not connected!" }
         return session
     }
 
     suspend fun openChannel(session: Session): ChannelSftp {
         val channel = session.openChannel("sftp") as ChannelSftp
-        channel.connect()
+        withContext(Dispatchers.IO) { channel.connect() }
         check(channel.isConnected) { "Channel is not connected!" }
         return channel
     }
@@ -222,10 +224,12 @@ class FileCluster(
     }
 
     suspend fun shareFile(channel: ChannelSftp, file: File, destinationFolder: String, fileName: String) {
-        channel.cd(channel.home)
-        channel.cd(parsePath(destinationFolder))
-        channel.put(parsePath(file.absolutePath), fileName)
-        channel.cd(channel.home)
+        withContext(Dispatchers.IO) {
+            channel.cd(channel.home)
+            channel.cd(parsePath(destinationFolder))
+            channel.put(parsePath(file.absolutePath), fileName)
+            channel.cd(channel.home)
+        }
     }
 
     suspend fun unzip(serviceId: ServiceId, file: String, unzipPath: String): AbstractPacket? {
@@ -244,7 +248,9 @@ class FileCluster(
         val fileNode = fileNodeRepository.getFileNode(serviceId) ?: error(
             "File node with service id $serviceId is not registered in the file cluster!"
         )
-        channel.get(parsePath(targetFile), parsePath(destinationFile.absolutePath))
+        withContext(Dispatchers.IO) {
+            channel.get(parsePath(targetFile), parsePath(destinationFile.absolutePath))
+        }
         return destinationFile
     }
 

--- a/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/FileCluster.kt
+++ b/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/FileCluster.kt
@@ -28,29 +28,12 @@ import org.apache.sshd.server.auth.password.PasswordAuthenticator
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
 import org.apache.sshd.sftp.server.SftpSubsystemFactory
-import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
-import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.cert.X509v3CertificateBuilder
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
-import org.bouncycastle.openssl.jcajce.JcaPEMWriter
-import org.bouncycastle.operator.ContentSigner
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.io.File
-import java.io.FileWriter
-import java.math.BigInteger
 import java.net.InetSocketAddress
 import java.nio.file.Paths
-import java.security.KeyPair
-import java.security.KeyPairGenerator
-import java.security.PrivateKey
-import java.security.PublicKey
-import java.security.cert.X509Certificate
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.util.*
 import java.util.logging.Filter
 import java.util.logging.Level
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class FileCluster(
@@ -67,15 +50,14 @@ class FileCluster(
         private const val PASSWORD_LENGTH = 32
         private const val SFTP_PORT_RANGE_START = 4000
         private const val SFTP_PORT_RANGE_END = 5000
-        private const val RSA_KEY_SIZE = 2048
-        private const val CERTIFICATE_EXPIRATION_DAYS = 31
-        private const val UNZIP_DELAY_MS = 500L
+        private val UNZIP_DELAY_MS = 500.milliseconds
     }
 
     private val ipFilter = IPFilter(this.eventManager, this.fileNodeRepository)
     private var sshd: SshServer? = null
     private val jsch = JSch()
     var port = -1
+        private set
 
     init {
         LogManager.rootLogger().filter = Filter { record
@@ -119,8 +101,7 @@ class FileCluster(
         sshd!!.passwordAuthenticator = PasswordAuthenticator { username, password, session ->
             runBlocking {
                 val node = fileNodeRepository.getFileNode(serviceId) ?: return@runBlocking false
-                val clientAddress = session.clientAddress
-                val hostname = when (clientAddress) {
+                val hostname = when (val clientAddress = session.clientAddress) {
                     is SshdSocketAddress -> {
                         clientAddress.hostName
                     }
@@ -152,14 +133,14 @@ class FileCluster(
 
         thisNode.startSession(hostname)
         thisNode.connected = true
-        runBlocking { fileNodeRepository.updateFileNode(thisNode) }
+        fileNodeRepository.updateFileNode(thisNode)
         eventManager.fireEvent(FileNodeConnectedEvent(thisNode.serviceId))
     }
 
-    private fun generatePort(fileNode: FileNode): Int {
+    private suspend fun generatePort(fileNode: FileNode): Int {
         if (System.getProperty("redicloud.filecluster.port") != null) {
             fileNode.port = System.getProperty("redicloud.filecluster.port").toInt()
-            runBlocking { fileNodeRepository.updateFileNode(fileNode) }
+            fileNodeRepository.updateFileNode(fileNode)
             return fileNode.port
         }
         val range = SFTP_PORT_RANGE_START..SFTP_PORT_RANGE_END
@@ -169,51 +150,11 @@ class FileCluster(
             val newPort = findFreePort(range)
             check(range.contains(newPort)) { "Port $newPort is not in range $range!" }
             fileNode.port = newPort
-            runBlocking { fileNodeRepository.updateFileNode(fileNode) }
+            fileNodeRepository.updateFileNode(fileNode)
             newPort
         }
         check(port != -1) { "No free port found for file cluster!" }
         return port
-    }
-
-    // TODO: implement certificate-based authentication for file cluster
-    @Suppress("UnusedPrivateMember")
-    private fun generateKey(): KeyPair {
-        val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-        keyPairGenerator.initialize(RSA_KEY_SIZE)
-        return keyPairGenerator.generateKeyPair()
-    }
-
-    // TODO: implement certificate-based authentication for file cluster
-    @Suppress("UnusedPrivateMember")
-    private fun saveCertificateToFile(certificate: X509Certificate, file: File) {
-        if (!file.parentFile.exists()) file.parentFile.mkdirs()
-        if (file.exists()) file.delete()
-        file.createNewFile()
-        val pemWriter = JcaPEMWriter(FileWriter(file))
-        pemWriter.writeObject(certificate)
-        pemWriter.close()
-    }
-
-    // TODO: implement certificate-based authentication for file cluster
-    @Suppress("UnusedPrivateMember")
-    private fun signCertificate(publicKey: PublicKey, privateKey: PrivateKey): X509Certificate {
-        val subject = X500Name("CN=Self-Signed")
-        val now = Instant.now()
-        val expirationTime = now.plus(CERTIFICATE_EXPIRATION_DAYS.toLong() * 3, ChronoUnit.DAYS)
-        val serialNumber = BigInteger.valueOf(now.toEpochMilli())
-        val publicKeyInfo = SubjectPublicKeyInfo.getInstance(publicKey.encoded)
-        val builder = X509v3CertificateBuilder(
-            subject,
-            serialNumber,
-            Date.from(now),
-            Date.from(expirationTime),
-            subject,
-            publicKeyInfo
-        )
-        val contentSigner: ContentSigner = JcaContentSignerBuilder("SHA256WithRSA").build(privateKey)
-        val certificateHolder: X509CertificateHolder = builder.build(contentSigner)
-        return JcaX509CertificateConverter().getCertificate(certificateHolder)
     }
 
     suspend fun disconnect(immediately: Boolean) {
@@ -225,7 +166,7 @@ class FileCluster(
         thisNode.endSession()
         thisNode.connected = false
         fileNodeRepository.shutdownAction.run()
-        runBlocking { fileNodeRepository.updateFileNode(thisNode) }
+        fileNodeRepository.updateFileNode(thisNode)
         eventManager.fireEvent(FileNodeDisconnectedEvent(thisNode.serviceId))
     }
 

--- a/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/FileNodeRepository.kt
+++ b/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/FileNodeRepository.kt
@@ -8,11 +8,13 @@ import dev.redicloud.database.DatabaseConnection
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.service.CachedServiceRepository
 import dev.redicloud.repository.service.ServiceRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlin.time.Duration.Companion.minutes
 
 class FileNodeRepository(
     databaseConnection: DatabaseConnection,
-    packetManager: PacketManager
+    packetManager: PacketManager,
+    scope: CoroutineScope
 ) : ServiceRepository(
     databaseConnection,
     packetManager
@@ -26,7 +28,8 @@ class FileNodeRepository(
         IFileNode::class,
         FileNode::class,
         5.minutes,
-        this
+        this,
+        scope
     ) {
         override suspend fun transformShutdownable(service: FileNode): FileNode = service
     }

--- a/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/filter/IPFilter.kt
+++ b/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/filter/IPFilter.kt
@@ -17,25 +17,16 @@ class IPFilter(
 
     init {
         eventManager.listen<FileNodeConnectedEvent> {
-            runBlocking {
-                val fileNode = fileNodeRepository.getFileNode(it.serviceId) ?: return@runBlocking
-                val ipAddress = fileNode.hostname
-                allowedIpCache.add(ipAddress)
-            }
+            val fileNode = fileNodeRepository.getFileNode(it.serviceId) ?: return@listen
+            allowedIpCache.add(fileNode.hostname)
         }
         eventManager.listen<FileNodeDisconnectedEvent> {
-            runBlocking {
-                val fileNode = fileNodeRepository.getFileNode(it.serviceId) ?: return@runBlocking
-                val ipAddress = fileNode.hostname
-                allowedIpCache.remove(ipAddress)
-            }
+            val fileNode = fileNodeRepository.getFileNode(it.serviceId) ?: return@listen
+            allowedIpCache.remove(fileNode.hostname)
         }
         eventManager.listen<NodeSuspendedEvent> {
-            runBlocking {
-                val fileNode = fileNodeRepository.getFileNode(it.serviceId) ?: return@runBlocking
-                val ipAddress = fileNode.hostname
-                allowedIpCache.remove(ipAddress)
-            }
+            val fileNode = fileNodeRepository.getFileNode(it.serviceId) ?: return@listen
+            allowedIpCache.remove(fileNode.hostname)
         }
         runBlocking {
             System.getProperty("redicloud.filter.ip.bypass", "127.0.0.1;0.0.0.0").split(";").forEach {

--- a/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/packet/UnzipPacket.kt
+++ b/file-cluster/src/main/kotlin/dev/redicloud/cluster/file/packet/UnzipPacket.kt
@@ -4,7 +4,6 @@ import dev.redicloud.api.packets.AbstractPacket
 import dev.redicloud.api.packets.IPacketManager
 import dev.redicloud.api.utils.toCloudFile
 import dev.redicloud.utils.unzipFile
-import kotlinx.coroutines.runBlocking
 
 class UnzipPacket(
     val zipLocation: String,
@@ -16,11 +15,11 @@ class UnzipPacket(
     Windows: https://www.somacon.com/p161.php
     Linux: apt install unzip
      */
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         val zipLocation = toCloudFile(zipLocation)
         val unzipLocation = toCloudFile(unzipLocation)
         unzipFile(zipLocation.absolutePath, unzipLocation.absolutePath)
-        runBlocking { respond(UnzipResponse()) }
+        respond(UnzipResponse())
     }
 }

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/ModuleHandler.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/ModuleHandler.kt
@@ -349,12 +349,12 @@ class ModuleHandler(
             moduleData.loaded = true
         } catch (e: Exception) {
             moduleData.lifeCycle = ModuleLifeCycle.UNLOAD
-            eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleInstance))
+            runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleInstance)) }
             throw CloudModuleException("Failed to execute LOAD tasks for module ${moduleData.id}", e)
         }
     }
 
-    override fun reloadModule(moduleId: String) = lock.withLock {
+    override fun reloadModule(moduleId: String): Unit = lock.withLock {
         val moduleData = getModuleData(moduleId)
         if (moduleData == null) {
             logger.warning("§cTried to reload module $moduleId that is not loaded!")
@@ -372,16 +372,16 @@ class ModuleHandler(
         try {
             val tasksCount = callTasks(moduleData.id, ModuleLifeCycle.RELOAD)
             moduleData.lifeCycle = ModuleLifeCycle.LOAD
-            eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance))
+            runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance)) }
             logger.info("Reloaded module %hc%${moduleData.id}%tc% with %hc%$tasksCount%tc% reload tasks!")
         } catch (e: Exception) {
             moduleData.lifeCycle = ModuleLifeCycle.UNLOAD
-            eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance))
+            runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance)) }
             throw CloudModuleException("Failed to reload module ${moduleData.id}", e)
         }
     }
 
-    override fun unloadModule(moduleId: String) = lock.withLock {
+    override fun unloadModule(moduleId: String): Unit = lock.withLock {
         if (!loaders.containsKey(moduleId)) {
             logger.warning("§cTried to unload module $moduleId that is not loaded!")
             return
@@ -412,7 +412,7 @@ class ModuleHandler(
         val loader = loaders[moduleData.id] ?: return 0
         var tasksCount = 0
         moduleData.lifeCycle = targetLifeCycle
-        eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance))
+        runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance)) }
         loader.tasks.filter { it.lifeCycle == targetLifeCycle }.sortedBy { it.order }.forEach {
             val function = it.function
             val injectParameters = mutableListOf<Any>()

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/ModuleHandler.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/ModuleHandler.kt
@@ -21,11 +21,10 @@ import dev.redicloud.modules.repository.ModuleWebRepository
 import dev.redicloud.modules.suggesters.*
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.utils.gson.gson
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.File
-import java.util.concurrent.locks.ReentrantLock
 import java.util.jar.JarFile
-import kotlin.concurrent.withLock
 import kotlin.reflect.full.*
 import kotlin.reflect.jvm.javaMethod
 
@@ -45,7 +44,7 @@ class ModuleHandler(
     }
 
     private val loaders = mutableMapOf<String, ModuleClassLoader>()
-    private val lock = ReentrantLock()
+    private val mutex = Mutex()
     private val moduleFiles = mutableListOf<File>()
     private val cachedDescriptions = mutableListOf<ModuleDescription>()
     val repositories = mutableListOf<ModuleWebRepository>()
@@ -82,47 +81,45 @@ class ModuleHandler(
         eventManager.fireEvent(ModuleHandlerInitializedEvent(this))
     }
 
-    override suspend fun updateModules(silent: Boolean, loadModules: Boolean) = lock.withLock {
-        runBlocking {
-            cachedDescriptions.forEach { description ->
-                @Suppress("TooGenericExceptionCaught")
-                try {
-                    val targetRepositories = if (description.cachedFile != null) {
-                        repositories.filter { it.isUpdateAvailable(description.id) }
-                    } else {
-                        emptyList()
-                    }
-
-                    if (targetRepositories.isEmpty()) return@forEach
-
-                    if (targetRepositories.size > 2) {
-                        logger.warning(
-                            "§cFound more than 2 repositories that have an update for module ${description.id}!"
-                        )
-                        targetRepositories.forEach {
-                            logger.warning(
-                                "§c - ${it.repoUrl} | ${it.getLatestVersion(description.id)}"
-                            )
-                        }
-                        return@forEach
-                    }
-
-                    val targetRepository = targetRepositories.first()
-                    val data = getModuleData(description.id)
-                    if (data != null && (data.loaded || data.lifeCycle == ModuleLifeCycle.LOAD)) {
-                        unloadModule(data.id)
-                    }
-                    targetRepository.download(description.id, description.version)
-                    detectModules()
-                    val file = moduleFiles.firstOrNull { it.name == "${description.id}-${description.version}.jar" }
-                    if (file == null) {
-                        logger.warning("§cFailed to find downloaded module ${description.id}!")
-                        return@forEach
-                    }
-                    if (loadModules) loadModule(file)
-                } catch (e: Exception) {
-                    logger.severe("Failed to update module ${description.id}!", e)
+    override suspend fun updateModules(silent: Boolean, loadModules: Boolean) = mutex.withLock {
+        cachedDescriptions.forEach { description ->
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val targetRepositories = if (description.cachedFile != null) {
+                    repositories.filter { it.isUpdateAvailable(description.id) }
+                } else {
+                    emptyList()
                 }
+
+                if (targetRepositories.isEmpty()) return@forEach
+
+                if (targetRepositories.size > 2) {
+                    logger.warning(
+                        "§cFound more than 2 repositories that have an update for module ${description.id}!"
+                    )
+                    targetRepositories.forEach {
+                        logger.warning(
+                            "§c - ${it.repoUrl} | ${it.getLatestVersion(description.id)}"
+                        )
+                    }
+                    return@forEach
+                }
+
+                val targetRepository = targetRepositories.first()
+                val data = getModuleData(description.id)
+                if (data != null && (data.loaded || data.lifeCycle == ModuleLifeCycle.LOAD)) {
+                    unloadModule(data.id)
+                }
+                targetRepository.download(description.id, description.version)
+                detectModules()
+                val file = moduleFiles.firstOrNull { it.name == "${description.id}-${description.version}.jar" }
+                if (file == null) {
+                    logger.warning("§cFailed to find downloaded module ${description.id}!")
+                    return@forEach
+                }
+                if (loadModules) loadModule(file)
+            } catch (e: Exception) {
+                logger.severe("Failed to update module ${description.id}!", e)
             }
         }
     }
@@ -193,7 +190,7 @@ class ModuleHandler(
         }
     }
 
-    fun unloadModules() {
+    suspend fun unloadModules() {
         loaders.map { it.value.data.id }.toList().forEach {
             try {
                 unloadModule(it)
@@ -203,7 +200,7 @@ class ModuleHandler(
         }
     }
 
-    fun detectModules() = lock.withLock {
+    suspend fun detectModules() = mutex.withLock {
         moduleFiles.clear()
         MODULES_FOLDER.getFile().listFiles()?.filter {
             it.isFile && it.extension == "jar"
@@ -233,7 +230,7 @@ class ModuleHandler(
         return description
     }
 
-    fun loadModule(file: File) = lock.withLock {
+    suspend fun loadModule(file: File) = mutex.withLock {
         if (!validateModuleFile(file)) return
         val description = loadDescription(file)
         if (loaders.any { it.value.data.id == description.id }) {
@@ -341,7 +338,7 @@ class ModuleHandler(
             }
     }
 
-    private fun executeLoadTasks(moduleData: ModuleData, description: ModuleDescription, moduleInstance: CloudModule) {
+    private suspend fun executeLoadTasks(moduleData: ModuleData, description: ModuleDescription, moduleInstance: CloudModule) {
         @Suppress("TooGenericExceptionCaught")
         try {
             val tasksCount = callTasks(moduleData.id, ModuleLifeCycle.LOAD)
@@ -349,12 +346,12 @@ class ModuleHandler(
             moduleData.loaded = true
         } catch (e: Exception) {
             moduleData.lifeCycle = ModuleLifeCycle.UNLOAD
-            runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleInstance)) }
+            eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleInstance))
             throw CloudModuleException("Failed to execute LOAD tasks for module ${moduleData.id}", e)
         }
     }
 
-    override fun reloadModule(moduleId: String): Unit = lock.withLock {
+    override suspend fun reloadModule(moduleId: String): Unit = mutex.withLock {
         val moduleData = getModuleData(moduleId)
         if (moduleData == null) {
             logger.warning("§cTried to reload module $moduleId that is not loaded!")
@@ -372,16 +369,16 @@ class ModuleHandler(
         try {
             val tasksCount = callTasks(moduleData.id, ModuleLifeCycle.RELOAD)
             moduleData.lifeCycle = ModuleLifeCycle.LOAD
-            runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance)) }
+            eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance))
             logger.info("Reloaded module %hc%${moduleData.id}%tc% with %hc%$tasksCount%tc% reload tasks!")
         } catch (e: Exception) {
             moduleData.lifeCycle = ModuleLifeCycle.UNLOAD
-            runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance)) }
+            eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance))
             throw CloudModuleException("Failed to reload module ${moduleData.id}", e)
         }
     }
 
-    override fun unloadModule(moduleId: String): Unit = lock.withLock {
+    override suspend fun unloadModule(moduleId: String): Unit = mutex.withLock {
         if (!loaders.containsKey(moduleId)) {
             logger.warning("§cTried to unload module $moduleId that is not loaded!")
             return
@@ -407,12 +404,12 @@ class ModuleHandler(
         return repositories.firstOrNull { it.hasModule(moduleId) }
     }
 
-    private fun callTasks(moduleId: String, targetLifeCycle: ModuleLifeCycle): Int {
+    private suspend fun callTasks(moduleId: String, targetLifeCycle: ModuleLifeCycle): Int {
         val moduleData = getModuleData(moduleId) ?: return 0
         val loader = loaders[moduleData.id] ?: return 0
         var tasksCount = 0
         moduleData.lifeCycle = targetLifeCycle
-        runBlocking { eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance)) }
+        eventManager.fireEvent(ModuleLifeCycleChangedEvent(moduleData.instance))
         loader.tasks.filter { it.lifeCycle == targetLifeCycle }.sortedBy { it.order }.forEach {
             val function = it.function
             val injectParameters = mutableListOf<Any>()
@@ -426,8 +423,8 @@ class ModuleHandler(
                 val instance = injector.getInstance(key)
                 injectParameters.add(instance)
             }
-            if (function.isSuspend) { // TODO test suspend
-                runBlocking { function.callSuspend(moduleData.instance, *injectParameters.toTypedArray()) }
+            if (function.isSuspend) {
+                function.callSuspend(moduleData.instance, *injectParameters.toTypedArray())
             } else {
                 function.javaMethod!!.invoke(moduleData.instance, *injectParameters.toTypedArray())
             }
@@ -452,7 +449,7 @@ class ModuleHandler(
         return loaders[moduleId]?.tasks?.any { it.lifeCycle == ModuleLifeCycle.RELOAD } ?: false
     }
 
-    override fun loadModule(moduleId: String) {
+    override suspend fun loadModule(moduleId: String) {
         loadModule(cachedDescriptions.firstOrNull { it.id == moduleId }?.cachedFile ?: return)
     }
 

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/InstallableModulesSuggester.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/InstallableModulesSuggester.kt
@@ -3,14 +3,13 @@ package dev.redicloud.modules.suggesters
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.modules.ModuleHandler
-import kotlinx.coroutines.runBlocking
 
 class InstallableModulesSuggester(
     private val moduleHandler: ModuleHandler
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
-        return moduleHandler.repositories.flatMap { runBlocking { it.getModuleIds() } }
+    override suspend fun suggest(context: CommandContext): Array<String> {
+        return moduleHandler.repositories.flatMap { it.getModuleIds() }
             .filter { id -> moduleHandler.getCachedDescriptions().none { it.id == id } }
             .toTypedArray()
     }

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/InstalledModulesSuggester.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/InstalledModulesSuggester.kt
@@ -8,7 +8,7 @@ class InstalledModulesSuggester(
     private val moduleHandler: ModuleHandler
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         return moduleHandler.getCachedDescriptions()
             .map { it.id }
             .toTypedArray()

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/LoadableModulesSuggester.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/LoadableModulesSuggester.kt
@@ -9,7 +9,7 @@ class LoadableModulesSuggester(
     private val moduleHandler: ModuleHandler
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         val descriptions = moduleHandler.getCachedDescriptions()
             .filter {
                 val data = moduleHandler.getModuleData(it.id)

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/ReloadableModulesSuggester.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/ReloadableModulesSuggester.kt
@@ -8,7 +8,7 @@ class ReloadableModulesSuggester(
     private val moduleHandler: ModuleHandler
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         return moduleHandler.getModuleDatas()
             .filter { moduleHandler.isModuleReloadable(it.id) }
             .map { it.id }

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/UninstallableModulesSuggester.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/UninstallableModulesSuggester.kt
@@ -8,7 +8,7 @@ class UninstallableModulesSuggester(
     private val moduleHandler: ModuleHandler
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         return moduleHandler.getCachedDescriptions()
             .map { it.id }
             .toTypedArray()

--- a/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/UnloadableModulesSuggester.kt
+++ b/modules/module-handler/src/main/kotlin/dev/redicloud/modules/suggesters/UnloadableModulesSuggester.kt
@@ -9,7 +9,7 @@ class UnloadableModulesSuggester(
     private val moduleHandler: ModuleHandler
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         val modules = moduleHandler.getModuleDatas()
         val loaded = modules.filter { it.lifeCycle == ModuleLifeCycle.LOAD || it.loaded }.map { it.description }
         val results = loaded + moduleHandler.getCachedDescriptions()

--- a/modules/papermc-updater/build.gradle.kts
+++ b/modules/papermc-updater/build.gradle.kts
@@ -18,7 +18,10 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(project(":repositories"))
+    testImplementation(project(":apis:base-api"))
+    testImplementation(project(":cache"))
     testImplementation(project(":utils"))
     testImplementation(project(":logging"))
     testImplementation(libs.kotlinx.coroutines)
+    testImplementation(libs.gson)
 }

--- a/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
+++ b/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
@@ -64,26 +64,25 @@ class PaperMcServerVersionHandler(
             }
             console.startAnimation(animation)
         }
-        if (lock) getLock(version).lock()
-        val jar = getJar(version)
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            if (jar.exists() && !force) return jar
-            downloadJar(version, jar)
-            downloadDefaultFiles(version, getFolder(version), logger)
-            lastUpdateChecks[version] = System.currentTimeMillis()
-        } catch (e: CloudVersionException) {
-            error = true
-            throw e
-        } catch (e: Exception) {
-            error = true
-            throw CloudVersionException("Failed to download version ${version.displayName}", e)
-        } finally {
-            downloaded = true
-            if (lock) getLock(version).unlock()
+        return getLock(version).withOptionalLock(lock) {
+            val jar = getJar(version)
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                if (jar.exists() && !force) return@withOptionalLock jar
+                downloadJar(version, jar)
+                downloadDefaultFiles(version, getFolder(version), logger)
+                lastUpdateChecks[version] = System.currentTimeMillis()
+            } catch (e: CloudVersionException) {
+                error = true
+                throw e
+            } catch (e: Exception) {
+                error = true
+                throw CloudVersionException("Failed to download version ${version.displayName}", e)
+            } finally {
+                downloaded = true
+            }
+            jar
         }
-
-        return jar
     }
 
     @Suppress("ThrowsCount")
@@ -263,42 +262,42 @@ class PaperMcServerVersionHandler(
             }
             console.startAnimation(animation)
         }
-        if (lock) getLock(version).lock()
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val jar = getJar(version)
-            if (!jar.exists()) download(version, true, lock = false)
+        getLock(version).withOptionalLock(lock) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val jar = getJar(version)
+                if (!jar.exists()) download(version, true, lock = false)
 
-            val versionDir = getFolder(version)
-            val tempDir = File(TEMP_SERVER_VERSION_FOLDER.getFile().absolutePath, UUID.randomUUID().toString())
-            withContext(Dispatchers.IO) {
-                tempDir.mkdirs()
-                versionDir.copyRecursively(tempDir, true)
+                val versionDir = getFolder(version)
+                val tempDir = File(TEMP_SERVER_VERSION_FOLDER.getFile().absolutePath, UUID.randomUUID().toString())
+                withContext(Dispatchers.IO) {
+                    tempDir.mkdirs()
+                    versionDir.copyRecursively(tempDir, true)
+                }
+                val tempJar = File(tempDir, jar.name)
+
+                val type = resolveVersionType(version)
+                val javaVersion = resolveJavaVersion(version)
+                executePatchProcess(version, type, javaVersion, tempDir, tempJar)
+
+                withContext(Dispatchers.IO) {
+                    if (!versionDir.exists()) versionDir.mkdirs()
+                    tempJar.copyTo(jar, true)
+                    cleanupPatchedFiles(version, type, tempDir, tempJar)
+                    versionDir.deleteRecursively()
+                    tempDir.copyRecursively(versionDir, true)
+                    tempDir.deleteRecursively()
+                    File(versionDir, ".patched").createNewFile()
+                }
+            } catch (e: CloudVersionException) {
+                error = true
+                throw e
+            } catch (e: Exception) {
+                error = true
+                throw CloudVersionException("Failed to patch version ${version.displayName}", e)
+            } finally {
+                patched = true
             }
-            val tempJar = File(tempDir, jar.name)
-
-            val type = resolveVersionType(version)
-            val javaVersion = resolveJavaVersion(version)
-            executePatchProcess(version, type, javaVersion, tempDir, tempJar)
-
-            withContext(Dispatchers.IO) {
-                if (!versionDir.exists()) versionDir.mkdirs()
-                tempJar.copyTo(jar, true)
-                cleanupPatchedFiles(version, type, tempDir, tempJar)
-                versionDir.deleteRecursively()
-                tempDir.copyRecursively(versionDir, true)
-                tempDir.deleteRecursively()
-                File(versionDir, ".patched").createNewFile()
-            }
-        } catch (e: CloudVersionException) {
-            error = true
-            throw e
-        } catch (e: Exception) {
-            error = true
-            throw CloudVersionException("Failed to patch version ${version.displayName}", e)
-        } finally {
-            patched = true
-            if (lock) getLock(version).unlock()
         }
     }
 

--- a/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
+++ b/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
@@ -13,7 +13,9 @@ import dev.redicloud.console.utils.toConsoleValue
 import dev.redicloud.logging.Logger
 import dev.redicloud.utils.*
 import io.ktor.client.request.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import java.io.File
@@ -103,10 +105,13 @@ class PaperMcServerVersionHandler(
         }
 
         val folder = getFolder(version)
-        if (folder.exists()) folder.deleteRecursively()
-        folder.mkdirs()
-        if (jar.exists()) jar.delete()
-        jar.writeBytes(response.readBytes())
+        val bytes = response.readBytes()
+        withContext(Dispatchers.IO) {
+            if (folder.exists()) folder.deleteRecursively()
+            folder.mkdirs()
+            if (jar.exists()) jar.delete()
+            jar.writeBytes(bytes)
+        }
 
         version.buildId = buildId.toString()
         serverVersionRepository.updateVersion(version)
@@ -160,8 +165,11 @@ class PaperMcServerVersionHandler(
                 )
                 return
             }
-            file.createNewFile()
-            file.writeBytes(response.readBytes())
+            val bytes = response.readBytes()
+            withContext(Dispatchers.IO) {
+                file.createNewFile()
+                file.writeBytes(bytes)
+            }
         } catch (e: Exception) {
             logger.warning(
                 "§cFailed to download default file ${toConsoleValue(
@@ -263,21 +271,25 @@ class PaperMcServerVersionHandler(
 
             val versionDir = getFolder(version)
             val tempDir = File(TEMP_SERVER_VERSION_FOLDER.getFile().absolutePath, UUID.randomUUID().toString())
-            tempDir.mkdirs()
-            versionDir.copyRecursively(tempDir, true)
+            withContext(Dispatchers.IO) {
+                tempDir.mkdirs()
+                versionDir.copyRecursively(tempDir, true)
+            }
             val tempJar = File(tempDir, jar.name)
 
             val type = resolveVersionType(version)
             val javaVersion = resolveJavaVersion(version)
             executePatchProcess(version, type, javaVersion, tempDir, tempJar)
 
-            if (!versionDir.exists()) versionDir.mkdirs()
-            tempJar.copyTo(jar, true)
-            cleanupPatchedFiles(version, type, tempDir, tempJar)
-            versionDir.deleteRecursively()
-            tempDir.copyRecursively(versionDir, true)
-            tempDir.deleteRecursively()
-            File(versionDir, ".patched").createNewFile()
+            withContext(Dispatchers.IO) {
+                if (!versionDir.exists()) versionDir.mkdirs()
+                tempJar.copyTo(jar, true)
+                cleanupPatchedFiles(version, type, tempDir, tempJar)
+                versionDir.deleteRecursively()
+                tempDir.copyRecursively(versionDir, true)
+                tempDir.deleteRecursively()
+                File(versionDir, ".patched").createNewFile()
+            }
         } catch (e: CloudVersionException) {
             error = true
             throw e

--- a/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
+++ b/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
@@ -13,6 +13,7 @@ import dev.redicloud.console.utils.toConsoleValue
 import dev.redicloud.logging.Logger
 import dev.redicloud.utils.*
 import io.ktor.client.request.*
+import kotlinx.coroutines.sync.Mutex
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import java.io.File
@@ -371,7 +372,7 @@ class PaperMcServerVersionHandler(
         return IServerVersionHandler.getDefaultHandler().patchCommand(type, javaVersion, jarToExecute)
     }
 
-    override fun getLock(version: ICloudServerVersion): SimpleLock {
+    override fun getLock(version: ICloudServerVersion): Mutex {
         return IServerVersionHandler.getDefaultHandler().getLock(version)
     }
 }

--- a/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
+++ b/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import io.ktor.client.statement.*
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.*
 import java.io.File
 import java.util.*
@@ -104,7 +105,7 @@ class PaperMcServerVersionHandler(
         }
 
         val folder = getFolder(version)
-        val bytes = response.readBytes()
+        val bytes = response.readRawBytes()
         withContext(Dispatchers.IO) {
             if (folder.exists()) folder.deleteRecursively()
             folder.mkdirs()
@@ -164,7 +165,7 @@ class PaperMcServerVersionHandler(
                 )
                 return
             }
-            val bytes = response.readBytes()
+            val bytes = response.readRawBytes()
             withContext(Dispatchers.IO) {
                 file.createNewFile()
                 file.writeBytes(bytes)
@@ -327,12 +328,14 @@ class PaperMcServerVersionHandler(
         findFreePort(PATCH_PORT_RANGE_START..PATCH_PORT_RANGE_END)
         val processBuilder = ProcessBuilder(patchCommand(type, javaVersion, tempJar))
         processBuilder.directory(tempDir)
-        val process = processBuilder.start()
-        console?.let {
-            val screen = console.createScreen("patch_${version.displayName}")
-            ScreenProcessHandler(process, screen)
+        withContext(Dispatchers.IO) {
+            val process = processBuilder.start()
+            console?.let {
+                val screen = console.createScreen("patch_${version.displayName}")
+                ScreenProcessHandler(process, screen)
+            }
+            process.waitFor(5.minutes.inWholeMilliseconds, TimeUnit.MILLISECONDS)
         }
-        process.waitFor(5.minutes.inWholeMilliseconds, TimeUnit.MILLISECONDS)
     }
 
     private fun cleanupPatchedFiles(

--- a/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
+++ b/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
@@ -13,12 +13,12 @@ import dev.redicloud.console.utils.toConsoleValue
 import dev.redicloud.logging.Logger
 import dev.redicloud.utils.*
 import io.ktor.client.request.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.withContext
 import io.ktor.client.statement.*
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit

--- a/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
+++ b/modules/papermc-updater/src/main/kotlin/dev/redicloud/module/papermc/PaperMcServerVersionHandler.kt
@@ -113,7 +113,7 @@ class PaperMcServerVersionHandler(
 
     private suspend fun downloadDefaultFiles(version: ICloudServerVersion, folder: File, logger: Logger) {
         val type = serverVersionTypeRepository.getType(version.typeId!!) ?: return
-        val downloader = MultiAsyncAction()
+        val downloader = ConcurrentBatch()
         val defaultFiles = mutableMapOf<String, String>()
         defaultFiles.putAll(version.defaultFiles)
         defaultFiles.putAll(type.defaultFiles)

--- a/modules/reset-module/src/main/kotlin/dev/redicloud/module/rest/RestHandler.kt
+++ b/modules/reset-module/src/main/kotlin/dev/redicloud/module/rest/RestHandler.kt
@@ -5,6 +5,7 @@ import dev.redicloud.api.modules.getListOrDefault
 import dev.redicloud.utils.SingleCache
 import io.javalin.http.Context
 import io.javalin.http.Handler
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlin.time.Duration.Companion.seconds
 
@@ -20,9 +21,10 @@ abstract class RestHandler(
 
     private val tokensCache = SingleCache<List<String>>(5.seconds) { config.getListOrDefault("tokens") { emptyList() } }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun handle(ctx: Context) {
         runBlocking {
-            runCatching {
+            try {
                 if (auth) {
                     val token = ctx.header("redicloud-token")
                     if (token == null) {
@@ -37,10 +39,12 @@ abstract class RestHandler(
                     }
                 }
                 handleRequest(ctx)
-            }.onFailure {
-                it.printStackTrace()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                e.printStackTrace()
                 ctx.status(HTTP_INTERNAL_ERROR)
-                ctx.json(mapOf("error" to it.message))
+                ctx.json(mapOf("error" to e.message))
             }
         }
     }

--- a/modules/reset-module/src/main/kotlin/dev/redicloud/module/rest/RestModule.kt
+++ b/modules/reset-module/src/main/kotlin/dev/redicloud/module/rest/RestModule.kt
@@ -23,7 +23,6 @@ import dev.redicloud.module.rest.handler.server.ProxyServerInfoHandler
 import dev.redicloud.module.rest.handler.version.ServerVersionInfoHandler
 import dev.redicloud.module.rest.handler.version.type.ServerVersionTypeInfoHandler
 import io.javalin.Javalin
-import kotlinx.coroutines.runBlocking
 
 class RestModule : CloudModule(), CloudInjectable {
 
@@ -47,7 +46,7 @@ class RestModule : CloudModule(), CloudInjectable {
 
     @ModuleTask(ModuleLifeCycle.LOAD)
     @Suppress("LongParameterList")
-    fun load(
+    suspend fun load(
         @Named("this") nodeId: ServiceId,
         nodeRepository: ICloudNodeRepository,
         serverRepository: ICloudServerRepository,
@@ -61,7 +60,7 @@ class RestModule : CloudModule(), CloudInjectable {
         app = Javalin.create()
         config = getStorage("rest-server")
         // verify the node exists before proceeding, throws if not found
-        runBlocking { nodeRepository.getNode(nodeId)!! }
+        nodeRepository.getNode(nodeId)!!
 
         playerFetcher = PlayerFetcher(playerRepository)
         nodeFetcher = NodeFetcher(nodeRepository)

--- a/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
+++ b/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("TooManyFunctions")
 class PacketManager(
     private val databaseConnection: DatabaseConnection,
     override val serviceId: ServiceId

--- a/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
+++ b/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.seconds
 
@@ -53,13 +52,13 @@ class PacketManager(
         ServiceType.entries.forEach {
             typedTopics[it] = databaseConnection.getCommunicationChannel(it.name.lowercase())
         }
+    }
 
-        runBlocking {
-            serviceTopic.subscribe(PackedPacket::class.java, messageListener)
-            broadcastTopic.subscribe(PackedPacket::class.java, messageListener)
-            typedTopics.forEach { (_, topic) ->
-                topic.subscribe(PackedPacket::class.java, messageListener)
-            }
+    suspend fun connect() {
+        serviceTopic.subscribe(PackedPacket::class.java, messageListener)
+        broadcastTopic.subscribe(PackedPacket::class.java, messageListener)
+        typedTopics.forEach { (_, topic) ->
+            topic.subscribe(PackedPacket::class.java, messageListener)
         }
     }
 

--- a/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
+++ b/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
@@ -74,27 +74,29 @@ class PacketManager(
                 val packet = gson.fromJson(data, packetClazz.java)
                 if (!packet.allowLocalReceiver && packet.sender == serviceId) return
                 LOGGER.finest("Received packet ${packetClazz.simpleName} in channel $channel")
-                packet.received(this@PacketManager)
-                packetsOfLast3Seconds.add(packet)
                 packetScope.launch {
-                    delay(3.seconds)
-                    packetsOfLast3Seconds.remove(packet)
-                }
-                ArrayList(packetResponses).filterNotNull().forEach {
-                    @Suppress("TooGenericExceptionCaught")
-                    try {
-                        it.handle(packet)
-                    } catch (e: Exception) {
-                        LOGGER.severe("Error while handling packet response ${packet::class.java.simpleName}!", e)
+                    packet.received(this@PacketManager)
+                    packetsOfLast3Seconds.add(packet)
+                    launch {
+                        delay(3.seconds)
+                        packetsOfLast3Seconds.remove(packet)
                     }
-                }
-                listeners.forEach {
-                    if (packet::class == it.packetClazz) {
+                    ArrayList(packetResponses).filterNotNull().forEach {
                         @Suppress("TooGenericExceptionCaught")
                         try {
-                            (it as PacketListener<AbstractPacket>).listener(packet)
+                            it.handle(packet)
                         } catch (e: Exception) {
-                            LOGGER.severe("Error while handling packet ${packet::class.java.simpleName}!", e)
+                            LOGGER.severe("Error while handling packet response ${packet::class.java.simpleName}!", e)
+                        }
+                    }
+                    listeners.forEach {
+                        if (packet::class == it.packetClazz) {
+                            @Suppress("TooGenericExceptionCaught")
+                            try {
+                                (it as PacketListener<AbstractPacket>).listener(packet)
+                            } catch (e: Exception) {
+                                LOGGER.severe("Error while handling packet ${packet::class.java.simpleName}!", e)
+                            }
                         }
                     }
                 }

--- a/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
+++ b/packets/src/main/kotlin/dev/redicloud/packets/PacketManager.kt
@@ -15,6 +15,7 @@ import dev.redicloud.utils.coroutineExceptionHandler
 import dev.redicloud.utils.gson.fixKotlinAnnotations
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -41,7 +42,7 @@ class PacketManager(
     private val listeners = mutableListOf<PacketListener<out AbstractPacket>>()
     internal val packetResponses = mutableListOf<PacketResponse>()
     internal val packetsOfLast3Seconds = mutableListOf<AbstractPacket>()
-    internal val packetScope = CoroutineScope(Dispatchers.IO + coroutineExceptionHandler)
+    internal val packetScope = CoroutineScope(SupervisorJob() + Dispatchers.IO + coroutineExceptionHandler)
     private val messageListener = createMessageListener()
 
     init {

--- a/repositories/src/main/kotlin/dev/redicloud/repository/cache/CachedDatabaseBucketRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/cache/CachedDatabaseBucketRepository.kt
@@ -5,6 +5,7 @@ import dev.redicloud.api.service.ServiceType
 import dev.redicloud.cache.ClusterCache
 import dev.redicloud.database.repository.DatabaseBucketRepository
 import dev.redicloud.packets.PacketManager
+import kotlinx.coroutines.CoroutineScope
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 
@@ -15,6 +16,7 @@ open class CachedDatabaseBucketRepository<I : Any, K : Any> (
     cacheClass: KClass<K>,
     cacheDuration: Duration,
     packetManager: PacketManager,
+    scope: CoroutineScope,
     vararg cacheTypes: ServiceType
 ) : DatabaseBucketRepository<I, K>(
     connection,
@@ -24,7 +26,7 @@ open class CachedDatabaseBucketRepository<I : Any, K : Any> (
 ) {
 
     protected val cache =
-        ClusterCache(name, connection.serviceId, cacheClass, cacheDuration, packetManager, *cacheTypes)
+        ClusterCache(name, connection.serviceId, cacheClass, cacheDuration, packetManager, scope, *cacheTypes)
 
     override suspend fun get(identifier: String): K? {
         if (cache.isCached(identifier)) return cache.get(identifier)

--- a/repositories/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionRepository.kt
@@ -12,6 +12,7 @@ import dev.redicloud.utils.*
 import dev.redicloud.utils.gson.fromJsonToList
 import dev.redicloud.utils.gson.gson
 import dev.redicloud.utils.gson.gsonInterfaceFactory
+import kotlinx.coroutines.CoroutineScope
 import java.io.File
 import java.util.*
 import kotlin.time.Duration.Companion.minutes
@@ -19,7 +20,8 @@ import kotlin.time.Duration.Companion.minutes
 class JavaVersionRepository(
     val serviceId: ServiceId,
     databaseConnection: DatabaseConnection,
-    packetManager: PacketManager
+    packetManager: PacketManager,
+    scope: CoroutineScope
 ) : CachedDatabaseBucketRepository<ICloudJavaVersion, CloudJavaVersion>(
     databaseConnection,
     "java-version",
@@ -27,6 +29,7 @@ class JavaVersionRepository(
     CloudJavaVersion::class,
     5.minutes,
     packetManager,
+    scope,
     ServiceType.NODE,
 ),
     ICloudJavaVersionRepository {
@@ -45,7 +48,7 @@ class JavaVersionRepository(
     override suspend fun getVersion(uniqueId: UUID): CloudJavaVersion? = get(uniqueId.toString())
 
     override suspend fun existsVersion(name: String): Boolean =
-        getVersions().any { it.name.lowercase() == name.lowercase() }
+        getVersions().any { it.name.equals(name, ignoreCase = true) }
 
     override suspend fun existsVersion(uniqueId: UUID): Boolean = exists(uniqueId.toString())
 
@@ -67,7 +70,7 @@ class JavaVersionRepository(
     }
 
     override suspend fun getVersion(name: String) =
-        getVersions().firstOrNull { it.name.lowercase() == name.lowercase() }
+        getVersions().firstOrNull { it.name.equals(name, ignoreCase = true) }
 
     override suspend fun getOnlineVersions(): List<CloudJavaVersion> =
         ONLINE_VERSION_CACHE.get()?.toList() ?: emptyList()
@@ -83,7 +86,7 @@ class JavaVersionRepository(
         return versions.map { file ->
             created.forEach { javaVersion ->
                 val byId = file.name.split("-").any { it.lowercase() == javaVersion.id.toString() }
-                val byName = file.name.lowercase() == javaVersion.name.lowercase()
+                val byName = file.name.equals(javaVersion.name, ignoreCase = true)
                 if (byId || byName) return@map javaVersion
             }
             val javaInfo = getVersionInfo(file.absolutePath)

--- a/repositories/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionUtils.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionUtils.kt
@@ -12,12 +12,12 @@ private val SUPPORTED_CLASS_VERSIONS = setOf(52, 61, 62, 63, 65)
 @Suppress("MagicNumber")
 private val UNTESTED_CLASS_VERSIONS = setOf(53, 54, 55, 56, 57, 58, 59, 60, 64)
 
-fun getJavaVersionsBetween(javaVersion1: CloudJavaVersion, javaVersion2: CloudJavaVersion): List<CloudJavaVersion> {
+suspend fun getJavaVersionsBetween(javaVersion1: CloudJavaVersion, javaVersion2: CloudJavaVersion): List<CloudJavaVersion> {
     return JavaVersionRepository.ONLINE_VERSION_CACHE.get()!!
         .filter { it.id >= javaVersion1.id && it.id <= javaVersion2.id }.toList()
 }
 
-fun getJavaVersion(): CloudJavaVersion {
+suspend fun getJavaVersion(): CloudJavaVersion {
     val version = System.getProperty("java.version")
     if (version.contains("-") && version.split(".").size < 2) {
         return JavaVersionRepository.ONLINE_VERSION_CACHE.get()!!.find { it.name == version.split("-")[0] }
@@ -38,7 +38,7 @@ fun isJavaVersionNotTested(version: CloudJavaVersion): Boolean {
     return version.id in UNTESTED_CLASS_VERSIONS
 }
 
-fun isJavaVersionUnsupported(version: CloudJavaVersion): Boolean {
+suspend fun isJavaVersionUnsupported(version: CloudJavaVersion): Boolean {
     return !isJavaVersionNotTested(getJavaVersion()) && !isJavaVersionNotTested(version)
 }
 

--- a/repositories/src/main/kotlin/dev/redicloud/repository/node/NodeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/node/NodeRepository.kt
@@ -10,12 +10,14 @@ import dev.redicloud.event.EventManager
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.service.CachedServiceRepository
 import dev.redicloud.repository.service.ServiceRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlin.time.Duration.Companion.minutes
 
 class NodeRepository(
     databaseConnection: DatabaseConnection,
     packetManager: PacketManager,
-    private val eventManager: EventManager
+    private val eventManager: EventManager,
+    scope: CoroutineScope
 ) : ServiceRepository(
     databaseConnection,
     packetManager
@@ -29,7 +31,8 @@ class NodeRepository(
         ICloudNode::class,
         CloudNode::class,
         5.minutes,
-        this
+        this,
+        scope
     ) {
         override suspend fun transformShutdownable(service: CloudNode): CloudNode {
             service.currentMemoryUsage = 0

--- a/repositories/src/main/kotlin/dev/redicloud/repository/player/PlayerRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/player/PlayerRepository.kt
@@ -10,13 +10,15 @@ import dev.redicloud.database.DatabaseConnection
 import dev.redicloud.event.EventManager
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.cache.CachedDatabaseBucketRepository
+import kotlinx.coroutines.CoroutineScope
 import java.util.UUID
 import kotlin.time.Duration.Companion.minutes
 
 class PlayerRepository(
     databaseConnection: DatabaseConnection,
     private val eventManager: EventManager,
-    packetManager: PacketManager
+    packetManager: PacketManager,
+    scope: CoroutineScope
 ) : CachedDatabaseBucketRepository<ICloudPlayer, CloudPlayer>(
     databaseConnection,
     "player",
@@ -24,6 +26,7 @@ class PlayerRepository(
     CloudPlayer::class,
     5.minutes,
     packetManager,
+    scope,
     ServiceType.NODE,
     ServiceType.MINECRAFT_SERVER,
     ServiceType.PROXY_SERVER
@@ -35,7 +38,7 @@ class PlayerRepository(
     }
 
     override suspend fun getPlayer(name: String): CloudPlayer? {
-        return getAll().firstOrNull { it.name.lowercase() == name.lowercase() }
+        return getAll().firstOrNull { it.name.equals(name, ignoreCase = true) }
     }
 
     override suspend fun createPlayer(cloudPlayer: ICloudPlayer): CloudPlayer {
@@ -72,7 +75,7 @@ class PlayerRepository(
     }
 
     override suspend fun existsPlayer(name: String): Boolean {
-        return getAll().any { it.name.lowercase() == name.lowercase() }
+        return getAll().any { it.name.equals(name, ignoreCase = true) }
     }
 
     override suspend fun getConnectedPlayers(): List<CloudPlayer> {

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/InternalServerRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/InternalServerRepository.kt
@@ -6,6 +6,7 @@ import dev.redicloud.api.service.server.ICloudServer
 import dev.redicloud.database.DatabaseConnection
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.service.CachedServiceRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.minutes
 
@@ -15,7 +16,8 @@ class InternalServerRepository<I : ICloudServer, K : CloudServer>(
     interfaceClass: KClass<I>,
     implementationClass: KClass<K>,
     targetType: ServiceType,
-    targetRepository: ServerRepository
+    targetRepository: ServerRepository,
+    scope: CoroutineScope
 ) : CachedServiceRepository<I, K>(
     databaseConnection,
     targetType,
@@ -23,7 +25,8 @@ class InternalServerRepository<I : ICloudServer, K : CloudServer>(
     interfaceClass,
     implementationClass,
     5.minutes,
-    targetRepository
+    targetRepository,
+    scope
 ) {
     override suspend fun transformShutdownable(service: K): K {
         service.state = CloudServerState.STOPPED

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/ServerRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/ServerRepository.kt
@@ -10,12 +10,14 @@ import dev.redicloud.database.DatabaseConnection
 import dev.redicloud.event.EventManager
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.service.ServiceRepository
+import kotlinx.coroutines.CoroutineScope
 
 class ServerRepository(
     databaseConnection: DatabaseConnection,
     private val serviceId: ServiceId,
     packetManager: PacketManager,
-    val eventManager: EventManager
+    val eventManager: EventManager,
+    scope: CoroutineScope
 ) : ServiceRepository(
     databaseConnection,
     packetManager
@@ -28,7 +30,8 @@ class ServerRepository(
         ICloudMinecraftServer::class,
         CloudMinecraftServer::class,
         ServiceType.MINECRAFT_SERVER,
-        this
+        this,
+        scope
     ).apply { internalRepositories.add(this) }
     val internalProxyServerRepository = InternalServerRepository(
         databaseConnection,
@@ -36,7 +39,8 @@ class ServerRepository(
         ICloudProxyServer::class,
         CloudProxyServer::class,
         ServiceType.PROXY_SERVER,
-        this
+        this,
+        scope
     ).apply { internalRepositories.add(this) }
 
     override suspend fun <T : ICloudServer> existsServer(serviceId: ServiceId): Boolean {

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionRepository.kt
@@ -13,12 +13,14 @@ import dev.redicloud.utils.getTextOfAPIWithFallback
 import dev.redicloud.utils.gson.fromJsonToList
 import dev.redicloud.utils.gson.gson
 import dev.redicloud.utils.gson.gsonInterfaceFactory
+import kotlinx.coroutines.CoroutineScope
 import java.util.*
 import kotlin.time.Duration.Companion.minutes
 
 class CloudServerVersionRepository(
     databaseConnection: DatabaseConnection,
-    packetManager: PacketManager
+    packetManager: PacketManager,
+    scope: CoroutineScope
 ) : CachedDatabaseBucketRepository<ICloudServerVersion, CloudServerVersion>(
     databaseConnection,
     "server-version",
@@ -26,6 +28,7 @@ class CloudServerVersionRepository(
     CloudServerVersion::class,
     5.minutes,
     packetManager,
+    scope,
     ServiceType.NODE
 ),
     ICloudServerVersionRepository {
@@ -44,7 +47,7 @@ class CloudServerVersionRepository(
     }
 
     override suspend fun getVersion(name: String): CloudServerVersion? {
-        return getVersions().firstOrNull { it.displayName.lowercase() == name.lowercase() }
+        return getVersions().firstOrNull { it.displayName.equals(name, ignoreCase = true) }
     }
 
     override suspend fun existsVersion(uniqueId: UUID): Boolean {
@@ -52,7 +55,7 @@ class CloudServerVersionRepository(
     }
 
     override suspend fun existsVersion(name: String): Boolean {
-        return getVersions().any { it.displayName.lowercase() == name.lowercase() }
+        return getVersions().any { it.displayName.equals(name, ignoreCase = true) }
     }
 
     override suspend fun updateVersion(version: ICloudServerVersion): CloudServerVersion {

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -16,6 +16,7 @@ import dev.redicloud.utils.gson.gson
 import dev.redicloud.utils.gson.gsonInterfaceFactory
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import kotlinx.coroutines.CoroutineScope
 import java.util.*
 import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
@@ -25,7 +26,8 @@ import kotlin.time.Duration.Companion.minutes
 class CloudServerVersionTypeRepository(
     databaseConnection: DatabaseConnection,
     private val console: Console?,
-    packetManager: PacketManager
+    packetManager: PacketManager,
+    scope: CoroutineScope
 ) : CachedDatabaseBucketRepository<ICloudServerVersionType, CloudServerVersionType>(
     databaseConnection,
     "server-version-types",
@@ -33,6 +35,7 @@ class CloudServerVersionTypeRepository(
     CloudServerVersionType::class,
     5.minutes,
     packetManager,
+    scope,
     ServiceType.NODE
 ),
     ICloudServerVersionTypeRepository {
@@ -69,10 +72,10 @@ class CloudServerVersionTypeRepository(
     }
 
     fun getLock(type: ICloudServerVersionType): ReentrantLock {
-        return locks.getOrPut(type.uniqueId) { java.util.concurrent.locks.ReentrantLock() }
+        return locks.getOrPut(type.uniqueId) { ReentrantLock() }
     }
 
-    override suspend fun getType(name: String) = getTypes().firstOrNull { it.name.lowercase() == name.lowercase() }
+    override suspend fun getType(name: String) = getTypes().firstOrNull { it.name.equals(name, ignoreCase = true) }
 
     override suspend fun getType(uniqueId: UUID) = get(uniqueId.toString())
 
@@ -81,7 +84,7 @@ class CloudServerVersionTypeRepository(
         return getType(version.typeId!!)
     }
 
-    override suspend fun existsType(name: String) = getTypes().any { it.name.lowercase() == name.lowercase() }
+    override suspend fun existsType(name: String) = getTypes().any { it.name.equals(name, ignoreCase = true) }
 
     override suspend fun existsType(uniqueId: UUID) = exists(uniqueId.toString())
 
@@ -136,8 +139,8 @@ class CloudServerVersionTypeRepository(
                 serverVersionType.getParsedConnectorURL().isValid()
             ) { "Connector download url of ${serverVersionType.connectorPluginName} is null!" }
             httpClient.get {
-                url(serverVersionType.getParsedConnectorURL().toExternalForm())
-            }.readBytes().let {
+                        url(serverVersionType.getParsedConnectorURL().toExternalForm())
+                    }.readRawBytes().let {
                 if (connectorFile.exists()) connectorFile.delete()
                 connectorFile.createNewFile()
                 connectorFile.writeBytes(it)

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -16,6 +16,7 @@ import dev.redicloud.utils.gson.gson
 import dev.redicloud.utils.gson.gsonInterfaceFactory
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
+import dev.redicloud.utils.withOptionalLock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -134,32 +135,31 @@ class CloudServerVersionTypeRepository(
             if (console == null) Level.INFO else Level.FINE,
             "Downloading connector for ${toConsoleValue(serverVersionType.name)}..."
         )
-        val mutex = getLock(serverVersionType)
-        if (lock) mutex.lock()
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            check(
-                serverVersionType.getParsedConnectorURL().isValid()
-            ) { "Connector download url of ${serverVersionType.connectorPluginName} is null!" }
-            httpClient.get {
-                url(serverVersionType.getParsedConnectorURL().toExternalForm())
-            }.readRawBytes().let {
-                withContext(Dispatchers.IO) {
-                    if (connectorFile.exists()) connectorFile.delete()
-                    connectorFile.createNewFile()
-                    connectorFile.writeBytes(it)
+        getLock(serverVersionType).withOptionalLock(lock) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                check(
+                    serverVersionType.getParsedConnectorURL().isValid()
+                ) { "Connector download url of ${serverVersionType.connectorPluginName} is null!" }
+                httpClient.get {
+                    url(serverVersionType.getParsedConnectorURL().toExternalForm())
+                }.readRawBytes().let {
+                    withContext(Dispatchers.IO) {
+                        if (connectorFile.exists()) connectorFile.delete()
+                        connectorFile.createNewFile()
+                        connectorFile.writeBytes(it)
+                    }
                 }
+                LOGGER.log(
+                    if (console == null) Level.FINE else Level.INFO,
+                    "Successfully downloaded connector for ${toConsoleValue(serverVersionType.name)}!"
+                )
+            } catch (e: Exception) {
+                LOGGER.severe("§cFailed to download connector ${toConsoleValue(connectorFile.name, false)}!", e)
+                error = true
+            } finally {
+                downloaded = true
             }
-            LOGGER.log(
-                if (console == null) Level.FINE else Level.INFO,
-                "Successfully downloaded connector for ${toConsoleValue(serverVersionType.name)}!"
-            )
-        } catch (e: Exception) {
-            LOGGER.severe("§cFailed to download connector ${toConsoleValue(connectorFile.name, false)}!", e)
-            error = true
-        } finally {
-            downloaded = true
-            if (lock) mutex.unlock()
         }
     }
 

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -14,9 +14,9 @@ import dev.redicloud.utils.*
 import dev.redicloud.utils.gson.fromJsonToList
 import dev.redicloud.utils.gson.gson
 import dev.redicloud.utils.gson.gsonInterfaceFactory
+import dev.redicloud.utils.withOptionalLock
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
-import dev.redicloud.utils.withOptionalLock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -17,7 +17,9 @@ import dev.redicloud.utils.gson.gsonInterfaceFactory
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import java.util.*
 import java.util.logging.Level
 import kotlin.time.Duration.Companion.minutes
@@ -142,9 +144,11 @@ class CloudServerVersionTypeRepository(
             httpClient.get {
                 url(serverVersionType.getParsedConnectorURL().toExternalForm())
             }.readRawBytes().let {
-                if (connectorFile.exists()) connectorFile.delete()
-                connectorFile.createNewFile()
-                connectorFile.writeBytes(it)
+                withContext(Dispatchers.IO) {
+                    if (connectorFile.exists()) connectorFile.delete()
+                    connectorFile.createNewFile()
+                    connectorFile.writeBytes(it)
+                }
             }
             LOGGER.log(
                 if (console == null) Level.FINE else Level.INFO,

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -17,8 +17,8 @@ import dev.redicloud.utils.gson.gsonInterfaceFactory
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.sync.Mutex
 import java.util.*
-import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
 import kotlin.time.Duration.Companion.minutes
 
@@ -44,7 +44,7 @@ class CloudServerVersionTypeRepository(
         gsonInterfaceFactory.register(IServerVersion::class, ServerVersion::class)
     }
 
-    private val locks = mutableMapOf<UUID, ReentrantLock>()
+    private val locks = mutableMapOf<UUID, Mutex>()
 
     companion object {
         private const val ANIMATION_TICK_MS = 200L
@@ -71,8 +71,8 @@ class CloudServerVersionTypeRepository(
         }
     }
 
-    fun getLock(type: ICloudServerVersionType): ReentrantLock {
-        return locks.getOrPut(type.uniqueId) { ReentrantLock() }
+    fun getLock(type: ICloudServerVersionType): Mutex {
+        return locks.getOrPut(type.uniqueId) { Mutex() }
     }
 
     override suspend fun getType(name: String) = getTypes().firstOrNull { it.name.equals(name, ignoreCase = true) }
@@ -132,7 +132,8 @@ class CloudServerVersionTypeRepository(
             if (console == null) Level.INFO else Level.FINE,
             "Downloading connector for ${toConsoleValue(serverVersionType.name)}..."
         )
-        if (lock) getLock(serverVersionType).lock()
+        val mutex = getLock(serverVersionType)
+        if (lock) mutex.lock()
         @Suppress("TooGenericExceptionCaught")
         try {
             check(
@@ -154,7 +155,7 @@ class CloudServerVersionTypeRepository(
             error = true
         } finally {
             downloaded = true
-            if (lock) getLock(serverVersionType).unlock()
+            if (lock) mutex.unlock()
         }
     }
 

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -139,8 +139,8 @@ class CloudServerVersionTypeRepository(
                 serverVersionType.getParsedConnectorURL().isValid()
             ) { "Connector download url of ${serverVersionType.connectorPluginName} is null!" }
             httpClient.get {
-                        url(serverVersionType.getParsedConnectorURL().toExternalForm())
-                    }.readRawBytes().let {
+                url(serverVersionType.getParsedConnectorURL().toExternalForm())
+            }.readRawBytes().let {
                 if (connectorFile.exists()) connectorFile.delete()
                 connectorFile.createNewFile()
                 connectorFile.writeBytes(it)

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
@@ -15,12 +15,12 @@ import dev.redicloud.console.utils.toConsoleValue
 import dev.redicloud.logging.LogManager
 import dev.redicloud.utils.*
 import io.ktor.client.request.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.withContext
 import io.ktor.client.statement.*
 import io.ktor.client.statement.readRawBytes
 import io.ktor.http.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
@@ -15,6 +15,7 @@ import dev.redicloud.console.utils.toConsoleValue
 import dev.redicloud.logging.LogManager
 import dev.redicloud.utils.*
 import io.ktor.client.request.*
+import kotlinx.coroutines.sync.Mutex
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import java.io.File
@@ -42,10 +43,10 @@ open class URLServerVersionHandler(
         private const val PATCH_PORT_RANGE_END = 60000
     }
 
-    protected val locks = mutableMapOf<UUID, SimpleLock>()
+    protected val locks = mutableMapOf<UUID, Mutex>()
 
-    override fun getLock(version: ICloudServerVersion): SimpleLock {
-        return locks.getOrPut(version.uniqueId) { SimpleLock() }
+    override fun getLock(version: ICloudServerVersion): Mutex {
+        return locks.getOrPut(version.uniqueId) { Mutex() }
     }
 
     override suspend fun download(version: ICloudServerVersion, force: Boolean, lock: Boolean): File {

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
@@ -69,24 +69,24 @@ open class URLServerVersionHandler(
             }
         }
         console.startAnimation(animation)
-        if (lock) getLock(version).lock()
-        val jar = getJar(version)
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            if (jar.exists() && !force) return jar
-            downloadJar(version, jar)
-            downloadDefaultFiles(version, getFolder(version))
-        } catch (e: CloudVersionException) {
-            error = true
-            throw e
-        } catch (e: Exception) {
-            error = true
-            throw CloudVersionException("Failed to download version ${version.displayName}", e)
-        } finally {
-            downloaded = true
-            if (lock) getLock(version).unlock()
+        return getLock(version).withOptionalLock(lock) {
+            val jar = getJar(version)
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                if (jar.exists() && !force) return@withOptionalLock jar
+                downloadJar(version, jar)
+                downloadDefaultFiles(version, getFolder(version))
+            } catch (e: CloudVersionException) {
+                error = true
+                throw e
+            } catch (e: Exception) {
+                error = true
+                throw CloudVersionException("Failed to download version ${version.displayName}", e)
+            } finally {
+                downloaded = true
+            }
+            jar
         }
-        return jar
     }
 
     @Suppress("ThrowsCount")
@@ -248,42 +248,42 @@ open class URLServerVersionHandler(
             }
         }
         console.startAnimation(animation)
-        if (lock) getLock(version).lock()
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val jar = getJar(version)
-            if (!jar.exists()) download(version, true, lock = false)
+        getLock(version).withOptionalLock(lock) {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                val jar = getJar(version)
+                if (!jar.exists()) download(version, true, lock = false)
 
-            val versionDir = getFolder(version)
-            val tempDir = File(TEMP_SERVER_VERSION_FOLDER.getFile().absolutePath, UUID.randomUUID().toString())
-            withContext(Dispatchers.IO) {
-                tempDir.mkdirs()
-                versionDir.copyRecursively(tempDir, true)
+                val versionDir = getFolder(version)
+                val tempDir = File(TEMP_SERVER_VERSION_FOLDER.getFile().absolutePath, UUID.randomUUID().toString())
+                withContext(Dispatchers.IO) {
+                    tempDir.mkdirs()
+                    versionDir.copyRecursively(tempDir, true)
+                }
+                val tempJar = File(tempDir, jar.name)
+
+                val type = resolveVersionType(version)
+                val javaVersion = resolveJavaVersion(version)
+                executePatchProcess(version, type, javaVersion, tempDir, tempJar)
+
+                withContext(Dispatchers.IO) {
+                    if (!versionDir.exists()) versionDir.mkdirs()
+                    tempJar.copyTo(jar, true)
+                    cleanupPatchedFiles(version, type, tempDir, tempJar)
+                    versionDir.deleteRecursively()
+                    tempDir.copyRecursively(versionDir, true)
+                    tempDir.deleteRecursively()
+                    File(versionDir, ".patched").createNewFile()
+                }
+            } catch (e: CloudVersionException) {
+                error = true
+                throw e
+            } catch (e: Exception) {
+                error = true
+                throw CloudVersionException("Failed to patch version ${version.displayName}", e)
+            } finally {
+                patched = true
             }
-            val tempJar = File(tempDir, jar.name)
-
-            val type = resolveVersionType(version)
-            val javaVersion = resolveJavaVersion(version)
-            executePatchProcess(version, type, javaVersion, tempDir, tempJar)
-
-            withContext(Dispatchers.IO) {
-                if (!versionDir.exists()) versionDir.mkdirs()
-                tempJar.copyTo(jar, true)
-                cleanupPatchedFiles(version, type, tempDir, tempJar)
-                versionDir.deleteRecursively()
-                tempDir.copyRecursively(versionDir, true)
-                tempDir.deleteRecursively()
-                File(versionDir, ".patched").createNewFile()
-            }
-        } catch (e: CloudVersionException) {
-            error = true
-            throw e
-        } catch (e: Exception) {
-            error = true
-            throw CloudVersionException("Failed to patch version ${version.displayName}", e)
-        } finally {
-            patched = true
-            if (lock) getLock(version).unlock()
         }
     }
 

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import io.ktor.client.statement.*
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.*
 import java.io.File
 import java.util.*
@@ -119,7 +120,7 @@ open class URLServerVersionHandler(
         }
 
         val folder = getFolder(version)
-        val bytes = response.readBytes()
+        val bytes = response.readRawBytes()
         withContext(Dispatchers.IO) {
             if (folder.exists()) folder.deleteRecursively()
             folder.mkdirs()
@@ -168,7 +169,7 @@ open class URLServerVersionHandler(
                 )
                 return
             }
-            val bytes = response.readBytes()
+            val bytes = response.readRawBytes()
             withContext(Dispatchers.IO) {
                 file.createNewFile()
                 file.writeBytes(bytes)
@@ -317,10 +318,12 @@ open class URLServerVersionHandler(
         findFreePort(PATCH_PORT_RANGE_START..PATCH_PORT_RANGE_END)
         val processBuilder = ProcessBuilder(patchCommand(type, javaVersion, tempJar))
         processBuilder.directory(tempDir)
-        val process = processBuilder.start()
-        val screen = console.createScreen("patch_${version.displayName}")
-        ScreenProcessHandler(process, screen)
-        process.waitFor(5.minutes.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        withContext(Dispatchers.IO) {
+            val process = processBuilder.start()
+            val screen = console.createScreen("patch_${version.displayName}")
+            ScreenProcessHandler(process, screen)
+            process.waitFor(5.minutes.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        }
     }
 
     private fun cleanupPatchedFiles(

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
@@ -15,7 +15,9 @@ import dev.redicloud.console.utils.toConsoleValue
 import dev.redicloud.logging.LogManager
 import dev.redicloud.utils.*
 import io.ktor.client.request.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import java.io.File
@@ -117,10 +119,13 @@ open class URLServerVersionHandler(
         }
 
         val folder = getFolder(version)
-        if (folder.exists()) folder.deleteRecursively()
-        folder.mkdirs()
-        if (jar.exists()) jar.delete()
-        jar.writeBytes(response.readBytes())
+        val bytes = response.readBytes()
+        withContext(Dispatchers.IO) {
+            if (folder.exists()) folder.deleteRecursively()
+            folder.mkdirs()
+            if (jar.exists()) jar.delete()
+            jar.writeBytes(bytes)
+        }
     }
 
     private suspend fun downloadDefaultFiles(version: ICloudServerVersion, folder: File) {
@@ -163,8 +168,11 @@ open class URLServerVersionHandler(
                 )
                 return
             }
-            file.createNewFile()
-            file.writeBytes(response.readBytes())
+            val bytes = response.readBytes()
+            withContext(Dispatchers.IO) {
+                file.createNewFile()
+                file.writeBytes(bytes)
+            }
         } catch (e: Exception) {
             logger.warning(
                 "§cFailed to download default file ${toConsoleValue(
@@ -248,21 +256,25 @@ open class URLServerVersionHandler(
 
             val versionDir = getFolder(version)
             val tempDir = File(TEMP_SERVER_VERSION_FOLDER.getFile().absolutePath, UUID.randomUUID().toString())
-            tempDir.mkdirs()
-            versionDir.copyRecursively(tempDir, true)
+            withContext(Dispatchers.IO) {
+                tempDir.mkdirs()
+                versionDir.copyRecursively(tempDir, true)
+            }
             val tempJar = File(tempDir, jar.name)
 
             val type = resolveVersionType(version)
             val javaVersion = resolveJavaVersion(version)
             executePatchProcess(version, type, javaVersion, tempDir, tempJar)
 
-            if (!versionDir.exists()) versionDir.mkdirs()
-            tempJar.copyTo(jar, true)
-            cleanupPatchedFiles(version, type, tempDir, tempJar)
-            versionDir.deleteRecursively()
-            tempDir.copyRecursively(versionDir, true)
-            tempDir.deleteRecursively()
-            File(versionDir, ".patched").createNewFile()
+            withContext(Dispatchers.IO) {
+                if (!versionDir.exists()) versionDir.mkdirs()
+                tempJar.copyTo(jar, true)
+                cleanupPatchedFiles(version, type, tempDir, tempJar)
+                versionDir.deleteRecursively()
+                tempDir.copyRecursively(versionDir, true)
+                tempDir.deleteRecursively()
+                File(versionDir, ".patched").createNewFile()
+            }
         } catch (e: CloudVersionException) {
             error = true
             throw e

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/handler/defaults/URLServerVersionHandler.kt
@@ -124,7 +124,7 @@ open class URLServerVersionHandler(
 
     private suspend fun downloadDefaultFiles(version: ICloudServerVersion, folder: File) {
         val type = serverVersionTypeRepository.getType(version.typeId!!) ?: return
-        val downloader = MultiAsyncAction()
+        val downloader = ConcurrentBatch()
         val defaultFiles = mutableMapOf<String, String>()
         defaultFiles.putAll(version.defaultFiles)
         defaultFiles.putAll(type.defaultFiles)

--- a/repositories/src/main/kotlin/dev/redicloud/repository/service/CachedServiceRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/service/CachedServiceRepository.kt
@@ -89,22 +89,11 @@ abstract class CachedServiceRepository<I : ICloudService, K : CloudService>(
         return exists(serviceId.id.toString())
     }
 
-    suspend fun createService(cloudService: I): K {
-        require(cloudService.serviceId.type == targetServiceType) {
-            "Service type does not match (expected ${targetServiceType.name}, got ${cloudService.serviceId.type.name})"
-        }
-        if (cloudService.connected && !connectedServices.contains(cloudService.serviceId)) {
-            connectedServices.add(cloudService.serviceId)
-        } else if (!cloudService.connected) {
-            connectedServices.remove(cloudService.serviceId)
-        }
-        if (!registeredServices.contains(cloudService.serviceId)) {
-            registeredServices.add(cloudService.serviceId)
-        }
-        return set(cloudService.serviceId.id.toString(), cloudService)
-    }
+    suspend fun createService(cloudService: I): K = saveService(cloudService)
 
-    suspend fun updateService(cloudService: I): K {
+    suspend fun updateService(cloudService: I): K = saveService(cloudService)
+
+    private suspend fun saveService(cloudService: I): K {
         require(cloudService.serviceId.type == targetServiceType) {
             "Service type does not match (expected ${targetServiceType.name}, got ${cloudService.serviceId.type.name})"
         }

--- a/repositories/src/main/kotlin/dev/redicloud/repository/service/CachedServiceRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/service/CachedServiceRepository.kt
@@ -7,6 +7,7 @@ import dev.redicloud.api.service.ServiceType
 import dev.redicloud.database.DatabaseConnection
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.cache.CachedDatabaseBucketRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
@@ -20,6 +21,7 @@ abstract class CachedServiceRepository<I : ICloudService, K : CloudService>(
     implClass: KClass<K>,
     cacheDuration: Duration,
     private val targetRepository: ServiceRepository,
+    scope: CoroutineScope,
     vararg cacheTypes: ServiceType
 ) : CachedDatabaseBucketRepository<I, K>(
     databaseConnection,
@@ -28,6 +30,7 @@ abstract class CachedServiceRepository<I : ICloudService, K : CloudService>(
     implClass,
     cacheDuration,
     packetManager,
+    scope,
     *cacheTypes
 ) {
 
@@ -76,7 +79,7 @@ abstract class CachedServiceRepository<I : ICloudService, K : CloudService>(
     }
 
     suspend fun getService(name: String): K? {
-        return getRegisteredServices().firstOrNull { it.name.lowercase() == name.lowercase() }
+        return getRegisteredServices().firstOrNull { it.name.equals(name, ignoreCase = true) }
     }
 
     suspend fun existsService(serviceId: ServiceId): Boolean {

--- a/repositories/src/main/kotlin/dev/redicloud/repository/template/configuration/ConfigurationTemplateRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/template/configuration/ConfigurationTemplateRepository.kt
@@ -8,13 +8,15 @@ import dev.redicloud.database.DatabaseConnection
 import dev.redicloud.event.EventManager
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.cache.CachedDatabaseBucketRepository
+import kotlinx.coroutines.CoroutineScope
 import java.util.UUID
 import kotlin.time.Duration.Companion.minutes
 
 class ConfigurationTemplateRepository(
     databaseConnection: DatabaseConnection,
     private val eventManager: EventManager,
-    packetManager: PacketManager
+    packetManager: PacketManager,
+    scope: CoroutineScope
 ) : CachedDatabaseBucketRepository<ICloudConfigurationTemplate, ConfigurationTemplate>(
     databaseConnection,
     "configuration-template",
@@ -22,6 +24,7 @@ class ConfigurationTemplateRepository(
     ConfigurationTemplate::class,
     5.minutes,
     packetManager,
+    scope,
     ServiceType.NODE
 ),
     ICloudConfigurationTemplateRepository {
@@ -31,7 +34,7 @@ class ConfigurationTemplateRepository(
     }
 
     override suspend fun getTemplate(name: String): ConfigurationTemplate? {
-        return getTemplates().firstOrNull { it.name.lowercase() == name.lowercase() }
+        return getTemplates().firstOrNull { it.name.equals(name, ignoreCase = true) }
     }
 
     override suspend fun existsTemplate(uniqueId: UUID): Boolean {
@@ -39,7 +42,7 @@ class ConfigurationTemplateRepository(
     }
 
     override suspend fun existsTemplate(name: String): Boolean {
-        return getTemplates().any { it.name.lowercase() == name.lowercase() }
+        return getTemplates().any { it.name.equals(name, ignoreCase = true) }
     }
 
     override suspend fun createTemplate(configurationTemplate: ICloudConfigurationTemplate): ConfigurationTemplate {

--- a/repositories/src/main/kotlin/dev/redicloud/repository/template/file/AbstractFileTemplateRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/template/file/AbstractFileTemplateRepository.kt
@@ -7,13 +7,15 @@ import dev.redicloud.api.template.file.ICloudFileTemplateRepository
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.cache.CachedDatabaseBucketRepository
 import dev.redicloud.repository.node.NodeRepository
+import kotlinx.coroutines.CoroutineScope
 import java.util.*
 import kotlin.time.Duration.Companion.minutes
 
 abstract class AbstractFileTemplateRepository(
     private val databaseConnection: IDatabaseConnection,
     private val nodeRepository: NodeRepository,
-    packetManager: PacketManager
+    packetManager: PacketManager,
+    scope: CoroutineScope
 ) : CachedDatabaseBucketRepository<ICloudFileTemplate, FileTemplate>(
     databaseConnection,
     "file-template",
@@ -21,6 +23,7 @@ abstract class AbstractFileTemplateRepository(
     FileTemplate::class,
     5.minutes,
     packetManager,
+    scope,
     ServiceType.NODE,
 ),
     ICloudFileTemplateRepository {
@@ -30,12 +33,12 @@ abstract class AbstractFileTemplateRepository(
     }
 
     override suspend fun getTemplate(displayName: String): FileTemplate? {
-        return getTemplates().firstOrNull { it.displayName.lowercase() == displayName.lowercase() }
+        return getTemplates().firstOrNull { it.displayName.equals(displayName, ignoreCase = true) }
     }
 
     override suspend fun getTemplate(name: String, prefix: String): FileTemplate? {
         return getTemplates().firstOrNull {
-            it.name.lowercase() == name.lowercase() && it.prefix.lowercase() == prefix.lowercase()
+            it.name.equals(name, ignoreCase = true) && it.prefix.equals(prefix, ignoreCase = true)
         }
     }
 
@@ -44,11 +47,11 @@ abstract class AbstractFileTemplateRepository(
     }
 
     override suspend fun existsTemplate(displayName: String): Boolean {
-        return getTemplates().any { it.displayName.lowercase() == displayName.lowercase() }
+        return getTemplates().any { it.displayName.equals(displayName, ignoreCase = true) }
     }
 
     override suspend fun existsTemplate(name: String, prefix: String): Boolean {
-        return getTemplates().any { it.name.lowercase() == name.lowercase() && it.prefix.lowercase() == prefix.lowercase() }
+        return getTemplates().any { it.name.equals(name, ignoreCase = true) && it.prefix.equals(prefix, ignoreCase = true) }
     }
 
     override suspend fun deleteTemplate(uniqueId: UUID): Boolean {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/FileCopier.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/FileCopier.kt
@@ -7,18 +7,19 @@ import dev.redicloud.api.version.IServerVersionHandler
 import dev.redicloud.logging.LogManager
 import dev.redicloud.repository.server.CloudServer
 import dev.redicloud.repository.server.version.CloudServerVersionTypeRepository
-import dev.redicloud.repository.template.file.AbstractFileTemplateRepository
 import dev.redicloud.repository.template.file.FileTemplate
 import dev.redicloud.server.factory.utils.StartDataSnapshot
 import dev.redicloud.utils.JarView
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.io.File
 
 class FileCopier(
     serverProcess: ServerProcess,
     cloudServer: CloudServer,
     private val serverVersionTypeRepository: CloudServerVersionTypeRepository,
-    fileTemplateRepository: AbstractFileTemplateRepository,
+    val templates: List<FileTemplate>,
     private val snapshot: StartDataSnapshot
 ) {
 
@@ -28,14 +29,9 @@ class FileCopier(
 
     val serviceId = cloudServer.serviceId
     val configurationTemplate = serverProcess.configurationTemplate
-    val templates: List<FileTemplate>
     val workDirectory: File
 
     init {
-        // get templates by given configuration template and collect also inherited templates
-        templates = configurationTemplate.fileTemplateIds.mapNotNull { runBlocking { fileTemplateRepository.getTemplate(it) } }
-            .flatMap { runBlocking { fileTemplateRepository.collectTemplates(it) } }
-        // create work directory
         workDirectory = if (configurationTemplate.static) {
             File(STATIC_FOLDER.getFile().absolutePath, "${cloudServer.name}-${serviceId.id}")
         } else {
@@ -49,11 +45,13 @@ class FileCopier(
         val pluginFolder = File(workDirectory, snapshot.versionType.connectorFolder)
         if (!pluginFolder.exists()) return
         val plugins = pluginFolder.listFiles()?.filter { it.isFile }?.filter { it.extension == "jar" } ?: return
-        plugins.forEach { jar ->
-            val jarView = JarView(jar)
-            if (!jarView.hasEntry("redicloud.properties")) return@forEach
-            jarView.close()
-            jar.delete()
+        withContext(Dispatchers.IO) {
+            plugins.forEach { jar ->
+                val jarView = JarView(jar)
+                if (!jarView.hasEntry("redicloud.properties")) return@forEach
+                jarView.close()
+                jar.delete()
+            }
         }
     }
 
@@ -99,7 +97,9 @@ class FileCopier(
             }
             val pluginFolder = File(workDirectory, snapshot.versionType.connectorFolder)
             if (!pluginFolder.exists()) pluginFolder.mkdirs()
-            connectorFile.copyTo(File(pluginFolder, connectorFile.name), overwrite = true)
+            withContext(Dispatchers.IO) {
+                connectorFile.copyTo(File(pluginFolder, connectorFile.name), overwrite = true)
+            }
         }
     }
 
@@ -115,12 +115,14 @@ class FileCopier(
             } else if (!versionHandler.isDownloaded(snapshot.version)) {
                 versionHandler.download(snapshot.version, lock = false)
             }
-            if (force && configurationTemplate.static || !configurationTemplate.static) {
-                versionHandler.getFolder(snapshot.version).copyRecursively(workDirectory)
-            } else {
-                val jar = versionHandler.getJar(snapshot.version)
-                if (jar.exists()) {
-                    jar.copyTo(File(workDirectory, jar.name), overwrite = true)
+            withContext(Dispatchers.IO) {
+                if (force && configurationTemplate.static || !configurationTemplate.static) {
+                    versionHandler.getFolder(snapshot.version).copyRecursively(workDirectory)
+                } else {
+                    val jar = versionHandler.getJar(snapshot.version)
+                    if (jar.exists()) {
+                        jar.copyTo(File(workDirectory, jar.name), overwrite = true)
+                    }
                 }
             }
             snapshot.versionType.doFileEdits(workDirectory, action)
@@ -134,8 +136,10 @@ class FileCopier(
     suspend fun copyTemplates(force: Boolean = true) {
         if (!force && configurationTemplate.static) return
         logger.fine("Copying templates for $serviceId")
-        templates.forEach {
-            it.folder.copyRecursively(workDirectory, overwrite = false)
+        withContext(Dispatchers.IO) {
+            templates.forEach {
+                it.folder.copyRecursively(workDirectory, overwrite = false)
+            }
         }
     }
 }

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/FileCopier.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/FileCopier.kt
@@ -11,9 +11,8 @@ import dev.redicloud.repository.template.file.AbstractFileTemplateRepository
 import dev.redicloud.repository.template.file.FileTemplate
 import dev.redicloud.server.factory.utils.StartDataSnapshot
 import dev.redicloud.utils.JarView
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.withLock
 import java.io.File
-import kotlin.concurrent.withLock
 
 class FileCopier(
     serverProcess: ServerProcess,
@@ -75,7 +74,7 @@ class FileCopier(
                 }
                 @Suppress("TooGenericExceptionCaught")
                 try {
-                    runBlocking { serverVersionTypeRepository.downloadConnector(snapshot.versionType, lock = false) }
+                    serverVersionTypeRepository.downloadConnector(snapshot.versionType, lock = false)
                     if (!connectorFile.exists()) {
                         logger.warning(
                             "Connector file for ${snapshot.versionType.name} does not exist! The server will not connect to the cloud cluster!"
@@ -111,23 +110,21 @@ class FileCopier(
         logger.fine("Copying files for $serviceId of version ${snapshot.version.displayName}")
         val versionHandler = IServerVersionHandler.getHandler(snapshot.versionType)
         versionHandler.getLock(snapshot.version).withLock {
-            runBlocking {
-                if (!versionHandler.isPatched(snapshot.version) && versionHandler.isPatchVersion(snapshot.version)) {
-                    versionHandler.patch(snapshot.version, lock = false)
-                } else if (!versionHandler.isDownloaded(snapshot.version)) {
-                    versionHandler.download(snapshot.version, lock = false)
-                }
-                if (force && configurationTemplate.static || !configurationTemplate.static) {
-                    versionHandler.getFolder(snapshot.version).copyRecursively(workDirectory)
-                } else {
-                    val jar = versionHandler.getJar(snapshot.version)
-                    if (jar.exists()) {
-                        jar.copyTo(File(workDirectory, jar.name), overwrite = true)
-                    }
-                }
-                snapshot.versionType.doFileEdits(workDirectory, action)
-                snapshot.version.doFileEdits(workDirectory, action)
+            if (!versionHandler.isPatched(snapshot.version) && versionHandler.isPatchVersion(snapshot.version)) {
+                versionHandler.patch(snapshot.version, lock = false)
+            } else if (!versionHandler.isDownloaded(snapshot.version)) {
+                versionHandler.download(snapshot.version, lock = false)
             }
+            if (force && configurationTemplate.static || !configurationTemplate.static) {
+                versionHandler.getFolder(snapshot.version).copyRecursively(workDirectory)
+            } else {
+                val jar = versionHandler.getJar(snapshot.version)
+                if (jar.exists()) {
+                    jar.copyTo(File(workDirectory, jar.name), overwrite = true)
+                }
+            }
+            snapshot.versionType.doFileEdits(workDirectory, action)
+            snapshot.version.doFileEdits(workDirectory, action)
         }
     }
 

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
@@ -42,7 +42,6 @@ import dev.redicloud.service.base.utils.ClusterConfiguration
 import dev.redicloud.utils.ConcurrentBatch
 import dev.redicloud.utils.zipFile
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.util.*
 import kotlin.time.Duration.Companion.milliseconds
@@ -80,18 +79,18 @@ class ServerFactory(
     }
 
     suspend fun getStartList(): List<ServerQueueInformation> {
-        return startQueue.toMutableList().sortedWith(
-            compareByDescending<ServerQueueInformation>
-                {
-                    if (it.serviceId != null) {
-                        val configuration = runBlocking {
-                            serverRepository.getServer<CloudServer>(it.serviceId!!)?.configurationTemplate
-                        }
-                        configuration?.startPriority ?: DEFAULT_START_PRIORITY
-                    } else {
-                        it.configurationTemplate.startPriority
-                    }
-                }.thenByDescending { it.queueTime }
+        val queueItems = startQueue.toMutableList()
+        val priorityMap = queueItems.associateWith { item ->
+            if (item.serviceId != null) {
+                val configuration = serverRepository.getServer<CloudServer>(item.serviceId!!)?.configurationTemplate
+                configuration?.startPriority ?: DEFAULT_START_PRIORITY
+            } else {
+                item.configurationTemplate.startPriority
+            }
+        }
+        return queueItems.sortedWith(
+            compareByDescending<ServerQueueInformation> { priorityMap[it] ?: DEFAULT_START_PRIORITY }
+                .thenByDescending { it.queueTime }
         ).toList()
     }
 

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
@@ -41,7 +41,9 @@ import dev.redicloud.server.factory.utils.*
 import dev.redicloud.service.base.utils.ClusterConfiguration
 import dev.redicloud.utils.ConcurrentBatch
 import dev.redicloud.utils.zipFile
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.*
 import kotlin.time.Duration.Companion.milliseconds
@@ -113,8 +115,10 @@ class ServerFactory(
             this.unregisterServer(serviceId, server)
             val workDir = File(STATIC_FOLDER.getFile(), "${server.name}-${server.serviceId.id}")
             if (workDir.exists() && workDir.isDirectory) {
-                if (!workDir.deleteRecursively()) {
-                    workDir.deleteOnExit()
+                withContext(Dispatchers.IO) {
+                    if (!workDir.deleteRecursively()) {
+                        workDir.deleteOnExit()
+                    }
                 }
             }
             eventManager.fireEvent(CloudServerDeleteEvent(server.serviceId, server.name))
@@ -240,11 +244,14 @@ class ServerFactory(
         cloudServer: CloudServer,
         snapshotData: StartDataSnapshot
     ) {
+        val templates = serverProcess.configurationTemplate.fileTemplateIds
+            .mapNotNull { fileTemplateRepository.getTemplate(it) }
+            .flatMap { fileTemplateRepository.collectTemplates(it) }
         val copier = FileCopier(
             serverProcess,
             cloudServer,
             serverVersionTypeRepository,
-            fileTemplateRepository,
+            templates,
             snapshotData
         )
         serverProcess.fileCopier = copier
@@ -344,11 +351,14 @@ class ServerFactory(
             nodeRepository.updateNode(thisNode)
 
             // copy the files to copy server necessary files
+            val templates = newConfigurationTemplate.fileTemplateIds
+                .mapNotNull { fileTemplateRepository.getTemplate(it) }
+                .flatMap { fileTemplateRepository.collectTemplates(it) }
             val copier = FileCopier(
                 serverProcess,
                 server,
                 serverVersionTypeRepository,
-                fileTemplateRepository,
+                templates,
                 snapshotData
             )
             serverProcess.fileCopier = copier
@@ -463,7 +473,7 @@ class ServerFactory(
                 )
             }
             fileCluster.deleteFolderRecursive(channel, toUniversalPath(workFolder))
-            workFolder.deleteRecursively()
+            withContext(Dispatchers.IO) { workFolder.deleteRecursively() }
             val event = CloudServerTransferredEvent(serverId, server.hostNodeId)
             server.hostNodeId = nodeId
             serverRepository.updateServer(server)

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
@@ -354,27 +354,8 @@ class ServerFactory(
             thisNode.hostedServers.add(server.serviceId)
             nodeRepository.updateNode(thisNode)
 
-            // copy the files to copy server necessary files
-            val templates = newConfigurationTemplate.fileTemplateIds
-                .mapNotNull { fileTemplateRepository.getTemplate(it) }
-                .flatMap { fileTemplateRepository.collectTemplates(it) }
-            val copier = FileCopier(
-                serverProcess,
-                server,
-                serverVersionTypeRepository,
-                templates,
-                snapshotData
-            )
+            val copier = prepareServerFiles(serverProcess, server, newConfigurationTemplate, snapshotData)
             serverProcess.fileCopier = copier
-
-            // copy all templates
-            copier.copyTemplates(false)
-            // copy all version files
-            copier.copyVersionFiles(false) { serverProcess.replacePlaceholders(it, snapshotData) }
-            // delete old connector files
-            copier.deleteConnectors()
-            // copy connector
-            copier.copyConnector()
 
             // start the server
             return serverProcess.start(server, serverScreen, snapshotData)
@@ -388,6 +369,29 @@ class ServerFactory(
             }
             return UnknownErrorStartResult(e)
         }
+    }
+
+    private suspend fun prepareServerFiles(
+        serverProcess: ServerProcess,
+        server: CloudServer,
+        configurationTemplate: ConfigurationTemplate,
+        snapshotData: StartDataSnapshot
+    ): FileCopier {
+        val templates = configurationTemplate.fileTemplateIds
+            .mapNotNull { fileTemplateRepository.getTemplate(it) }
+            .flatMap { fileTemplateRepository.collectTemplates(it) }
+        val copier = FileCopier(
+            serverProcess,
+            server,
+            serverVersionTypeRepository,
+            templates,
+            snapshotData
+        )
+        copier.copyTemplates(false)
+        copier.copyVersionFiles(false) { serverProcess.replacePlaceholders(it, snapshotData) }
+        copier.deleteConnectors()
+        copier.copyConnector()
+        return copier
     }
 
     @Suppress("ThrowsCount")

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
@@ -39,7 +39,7 @@ import dev.redicloud.server.factory.screens.ServerScreenParser
 import dev.redicloud.server.factory.screens.ServerScreenSuggester
 import dev.redicloud.server.factory.utils.*
 import dev.redicloud.service.base.utils.ClusterConfiguration
-import dev.redicloud.utils.MultiAsyncAction
+import dev.redicloud.utils.ConcurrentBatch
 import dev.redicloud.utils.zipFile
 import kotlinx.coroutines.runBlocking
 import java.io.File
@@ -484,7 +484,7 @@ class ServerFactory(
     suspend fun shutdown(force: Boolean = false) {
         if (!force && shutdown) return
         shutdown = true
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         hostedProcesses.toList().forEach {
             actions.add {
                 try {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
@@ -41,6 +41,7 @@ import dev.redicloud.server.factory.utils.*
 import dev.redicloud.service.base.utils.ClusterConfiguration
 import dev.redicloud.utils.ConcurrentBatch
 import dev.redicloud.utils.zipFile
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -63,7 +64,8 @@ class ServerFactory(
     private val clusterConfiguration: ClusterConfiguration,
     private val configurationTemplateRepository: ConfigurationTemplateRepository,
     private val eventManager: EventManager,
-    private val fileCluster: FileCluster
+    private val fileCluster: FileCluster,
+    private val scope: CoroutineScope
 ) : ICloudServerFactory, RemoteServerFactory(databaseConnection, nodeRepository, serverRepository) {
 
     companion object {
@@ -197,7 +199,8 @@ class ServerFactory(
             bindHost,
             clusterConfiguration,
             serviceId,
-            hostingId
+            hostingId,
+            scope
         )
     }
 
@@ -314,7 +317,8 @@ class ServerFactory(
             bindHost,
             clusterConfiguration,
             serviceId,
-            hostingId
+            hostingId,
+            scope
         )
         hostedProcesses.add(serverProcess)
         @Suppress("TooGenericExceptionCaught")

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
@@ -41,8 +41,10 @@ import dev.redicloud.server.factory.utils.*
 import dev.redicloud.service.base.utils.ClusterConfiguration
 import dev.redicloud.utils.ConcurrentBatch
 import dev.redicloud.utils.zipFile
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import kotlin.time.Duration.Companion.milliseconds
 import java.util.*
 
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -66,7 +68,7 @@ class ServerFactory(
     companion object {
         private val logger = LogManager.logger(ServerFactory::class)
         private const val DEFAULT_START_PRIORITY = 50
-        private const val LOCK_RELEASE_DELAY_MS = 50L
+        private val LOCK_RELEASE_DELAY = 50.milliseconds
     }
 
     override val hostedProcesses: MutableList<ServerProcess> = mutableListOf()
@@ -221,7 +223,7 @@ class ServerFactory(
                 )
             }
         } finally {
-            Thread.sleep(LOCK_RELEASE_DELAY_MS)
+            delay(LOCK_RELEASE_DELAY)
             idLock.unlock()
         }
     }

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerFactory.kt
@@ -44,8 +44,8 @@ import dev.redicloud.utils.zipFile
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.File
-import kotlin.time.Duration.Companion.milliseconds
 import java.util.*
+import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("LongParameterList", "TooManyFunctions")
 class ServerFactory(

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerProcess.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerProcess.kt
@@ -26,9 +26,10 @@ import dev.redicloud.service.base.utils.ClusterConfiguration
 import dev.redicloud.utils.blockPort
 import dev.redicloud.utils.findFreePort
 import dev.redicloud.utils.freePort
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.seconds
 
@@ -40,7 +41,8 @@ class ServerProcess(
     private val bindHost: String,
     private val clusterConfiguration: ClusterConfiguration,
     override val serverId: ServiceId,
-    override val hostServiceId: ServiceId
+    override val hostServiceId: ServiceId,
+    private val scope: CoroutineScope
 ) : ICloudServerProcess {
 
     override val port: Int
@@ -113,7 +115,7 @@ class ServerProcess(
         }
         // create handler and listen for exit
         processHandler = ScreenProcessHandler(process!!, serverScreen)
-        processHandler!!.onExit { runBlocking { stop(internalCall = true) } }
+        processHandler!!.onExit { scope.launch { stop(internalCall = true) } }
 
         cloudServer.state = CloudServerState.STARTING
         cloudServer.port = port

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerProcess.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/ServerProcess.kt
@@ -27,6 +27,7 @@ import dev.redicloud.utils.blockPort
 import dev.redicloud.utils.findFreePort
 import dev.redicloud.utils.freePort
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.seconds
@@ -53,7 +54,7 @@ class ServerProcess(
     companion object {
         private val logger = LogManager.logger(ServerProcess::class)
         private const val DEFAULT_START_PORT = 40000
-        private const val STOP_POLL_INTERVAL_MS = 1000L
+        private val STOP_POLL_INTERVAL = 1.seconds
         private const val JAVA_8_MAJOR_VERSION = 8
         val SERVER_STOP_TIMEOUT = System.getProperty("redicloud.server.stop.timeout", "20").toInt()
     }
@@ -177,9 +178,7 @@ class ServerProcess(
         if (answer != null) {
             var seconds = 0
             while (cloudServer != null && cloudServer?.connected == true && seconds < SERVER_STOP_TIMEOUT) {
-                withContext(Dispatchers.IO) {
-                    Thread.sleep(STOP_POLL_INTERVAL_MS)
-                }
+                delay(STOP_POLL_INTERVAL)
                 seconds++
                 cloudServer = serverRepository.getServer(serverId)
             }

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/screens/ServerScreen.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/screens/ServerScreen.kt
@@ -7,7 +7,6 @@ import dev.redicloud.console.Console
 import dev.redicloud.console.utils.Screen
 import dev.redicloud.packets.PacketManager
 import dev.redicloud.service.base.packets.ScreenCommandPacket
-import dev.redicloud.utils.defaultScope
 import kotlinx.coroutines.launch
 
 class ServerScreen(
@@ -24,7 +23,7 @@ class ServerScreen(
     }
     companion object {
         private const val MAX_STORED_LINES = 100
-        val SCREEN_LINE_FORMAT = System.getProperty("redicloud.screen.line", "§8[%hc%%name%§8] %tc%%message%")
+        val SCREEN_LINE_FORMAT: String = System.getProperty("redicloud.screen.line", "§8[%hc%%name%§8] %tc%%message%")
     }
 
     override fun println(text: String) {
@@ -37,6 +36,6 @@ class ServerScreen(
     }
 
     fun executeCommand(command: String) {
-        defaultScope.launch { packetManager?.publish(ScreenCommandPacket(command), serviceId) }
+        console.commandScope.launch { packetManager?.publish(ScreenCommandPacket(command), serviceId) }
     }
 }

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/screens/ServerScreenParser.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/screens/ServerScreenParser.kt
@@ -7,7 +7,7 @@ class ServerScreenParser(
     private val console: Console
 ) : ICommandArgumentParser<ServerScreen> {
 
-    override fun parse(parameter: String): ServerScreen? {
+    override suspend fun parse(parameter: String): ServerScreen? {
         val screen = console.getScreen(parameter) ?: return null
         if (screen !is ServerScreen) return null
         return screen

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/screens/ServerScreenSuggester.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/screens/ServerScreenSuggester.kt
@@ -8,7 +8,7 @@ class ServerScreenSuggester(
     private val console: Console
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         return console.getScreens().filterIsInstance<ServerScreen>().map { it.name }.toTypedArray()
     }
 }

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerDeleteTask.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerDeleteTask.kt
@@ -4,7 +4,7 @@ import dev.redicloud.api.exceptions.CloudServerException
 import dev.redicloud.logging.LogManager
 import dev.redicloud.server.factory.ServerFactory
 import dev.redicloud.tasks.CloudTask
-import dev.redicloud.utils.MultiAsyncAction
+import dev.redicloud.utils.ConcurrentBatch
 
 class CloudServerDeleteTask(
     private val serverFactory: ServerFactory
@@ -15,7 +15,7 @@ class CloudServerDeleteTask(
     }
 
     override suspend fun execute(): Boolean {
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         serverFactory.deleteQueue.forEach { queued ->
             serverFactory.deleteQueue.remove(queued)
             actions.add {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStartTask.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStartTask.kt
@@ -13,7 +13,7 @@ import dev.redicloud.repository.server.ServerRepository
 import dev.redicloud.server.factory.*
 import dev.redicloud.server.factory.utils.*
 import dev.redicloud.tasks.CloudTask
-import dev.redicloud.utils.MultiAsyncAction
+import dev.redicloud.utils.ConcurrentBatch
 import dev.redicloud.utils.coroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -74,7 +74,7 @@ class CloudServerStartTask(
     }
 
     override suspend fun execute(): Boolean {
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         serverFactory.getStartList().forEach { info ->
             if (!info.isNextNode(serverFactory.hostingId)) return@forEach
             val name = if (info.serviceId == null) info.configurationTemplate.name else info.serviceId?.toName() ?: "unknown"

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStartTask.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStartTask.kt
@@ -17,6 +17,7 @@ import dev.redicloud.utils.MultiAsyncAction
 import dev.redicloud.utils.coroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.newSingleThreadContext
 
@@ -69,7 +70,7 @@ class CloudServerStartTask(
         private val logger = LogManager.logger(CloudServerStartTask::class)
 
         @OptIn(DelicateCoroutinesApi::class)
-        private val scope = CoroutineScope(newSingleThreadContext("server-factory-start") + coroutineExceptionHandler)
+        private val scope = CoroutineScope(SupervisorJob() + newSingleThreadContext("server-factory-start") + coroutineExceptionHandler)
     }
 
     override suspend fun execute(): Boolean {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStartTask.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStartTask.kt
@@ -70,7 +70,8 @@ class CloudServerStartTask(
         private val logger = LogManager.logger(CloudServerStartTask::class)
 
         @OptIn(DelicateCoroutinesApi::class)
-        private val scope = CoroutineScope(SupervisorJob() + newSingleThreadContext("server-factory-start") + coroutineExceptionHandler)
+        private val scope =
+            CoroutineScope(SupervisorJob() + newSingleThreadContext("server-factory-start") + coroutineExceptionHandler)
     }
 
     override suspend fun execute(): Boolean {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStopTask.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerStopTask.kt
@@ -10,7 +10,7 @@ import dev.redicloud.repository.server.ServerRepository
 import dev.redicloud.repository.template.configuration.ConfigurationTemplate
 import dev.redicloud.repository.template.configuration.ConfigurationTemplateRepository
 import dev.redicloud.server.factory.ServerFactory
-import dev.redicloud.utils.MultiAsyncAction
+import dev.redicloud.utils.ConcurrentBatch
 import dev.redicloud.utils.pop
 
 class CloudServerStopTask(
@@ -35,7 +35,7 @@ class CloudServerStopTask(
         val thisNode = nodeRepository.getNode(serviceId)!!
         if (!thisNode.master) return false
 
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         val servers = serverRepository.getConnectedServers()
             .filter { it.state == CloudServerState.RUNNING }
             .filter { !it.hidden }
@@ -72,7 +72,7 @@ class CloudServerStopTask(
         templateStartedServers: Map<ServiceId, Int>,
         stopAble: MutableList<CloudServer>
     ) {
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         templateStartedServers.forEach { (nodeId, count) ->
             if (template.minStartedServices >= count) return@forEach
             if (template.minStartedServicesPerNode in 1 until count) {
@@ -99,7 +99,7 @@ class CloudServerStopTask(
         if (template.minStartedServices !in 1 until started) return
         if (stopAble.isEmpty()) return
 
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         val countToStop = started - template.minStartedServices
         stopAble.filter { !preQueuedStop.contains(it.serviceId) }
             .filter { !serverFactory.stopQueue.contains(it.serviceId) }
@@ -113,7 +113,7 @@ class CloudServerStopTask(
     }
 
     private suspend fun processRequestedServerStops() {
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         serverFactory.stopQueue.forEach {
             actions.add {
                 try {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerTransferTask.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerTransferTask.kt
@@ -4,7 +4,7 @@ import dev.redicloud.api.exceptions.CloudServerException
 import dev.redicloud.logging.LogManager
 import dev.redicloud.server.factory.ServerFactory
 import dev.redicloud.tasks.CloudTask
-import dev.redicloud.utils.MultiAsyncAction
+import dev.redicloud.utils.ConcurrentBatch
 
 class CloudServerTransferTask(
     private val serverFactory: ServerFactory
@@ -15,7 +15,7 @@ class CloudServerTransferTask(
     }
 
     override suspend fun execute(): Boolean {
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         serverFactory.transferQueue.forEach {
             actions.add {
                 try {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerUnregisterTask.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/task/CloudServerUnregisterTask.kt
@@ -8,7 +8,7 @@ import dev.redicloud.api.service.server.ICloudServerRepository
 import dev.redicloud.logging.LogManager
 import dev.redicloud.server.factory.ServerFactory
 import dev.redicloud.tasks.CloudTask
-import dev.redicloud.utils.MultiAsyncAction
+import dev.redicloud.utils.ConcurrentBatch
 
 class CloudServerUnregisterTask(
     private val thisNodeId: ServiceId,
@@ -25,7 +25,7 @@ class CloudServerUnregisterTask(
         if (nodeRepository.getMasterNode()?.serviceId != thisNodeId) {
             return false
         }
-        val actions = MultiAsyncAction()
+        val actions = ConcurrentBatch()
         serverFactory.unregisterQueue.forEach { serviceId ->
             serverFactory.unregisterQueue.remove(serviceId)
             if (!serverRepository.existsServer<ICloudServer>(serviceId)) {

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/utils/StartDataSnapshot.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/utils/StartDataSnapshot.kt
@@ -21,7 +21,7 @@ class StartDataSnapshot private constructor(
         private val easyCache = EasyCache<StartDataSnapshot, ICloudConfigurationTemplate>(3.seconds) {
             StartDataSnapshot(it!!)
         }
-        fun of(configurationTemplate: ICloudConfigurationTemplate) = easyCache.get(configurationTemplate)
+        suspend fun of(configurationTemplate: ICloudConfigurationTemplate) = easyCache.get(configurationTemplate)
             ?: easyCache.get(configurationTemplate)!!
     }
 

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/utils/StartDataSnapshot.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/utils/StartDataSnapshot.kt
@@ -11,6 +11,7 @@ import dev.redicloud.repository.server.version.CloudServerVersionRepository
 import dev.redicloud.repository.server.version.CloudServerVersionType
 import dev.redicloud.repository.server.version.CloudServerVersionTypeRepository
 import dev.redicloud.utils.EasyCache
+import kotlinx.coroutines.CancellationException
 import kotlin.time.Duration.Companion.seconds
 
 class StartDataSnapshot private constructor(
@@ -75,17 +76,25 @@ class StartDataSnapshot private constructor(
         this.javaVersion = javaVersion
 
         // get the version handler and update/patch the version if needed
-        val versionHandler = runCatching { IServerVersionHandler.getHandler(versionType) }.getOrNull()
+        val versionHandler = try {
+            IServerVersionHandler.getHandler(versionType)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }
         if (versionHandler == null) {
             startResult = UnknownServerVersionHandlerResult(version.typeId)
             return startResult
         }
         this.versionHandler = versionHandler
-        val hostName = runCatching {
-            nodeRepository.getNode(
-                hostServiceId
-            )
-        }.getOrNull()?.currentOrLastSession()?.ipAddress
+        val hostName = try {
+            nodeRepository.getNode(hostServiceId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        }?.currentOrLastSession()?.ipAddress
         if (hostName == null) {
             startResult = UnknownErrorStartResult(Exception("Cant find host node: ${hostServiceId.toName()}"))
             return startResult

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/BaseService.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/BaseService.kt
@@ -62,9 +62,11 @@ import dev.redicloud.service.base.suggester.*
 import dev.redicloud.service.base.utils.ClusterConfiguration
 import dev.redicloud.tasks.CloudTaskManager
 import dev.redicloud.utils.InjectorModule
-import dev.redicloud.utils.defaultScope
-import dev.redicloud.utils.ioScope
+import dev.redicloud.utils.coroutineExceptionHandler
 import dev.redicloud.utils.loadProperties
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -83,6 +85,8 @@ abstract class BaseService(
         val LOGGER = LogManager.logger(BaseService::class)
         var SHUTTINGDOWN = false
     }
+
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default + coroutineExceptionHandler)
 
     val databaseConnection: DatabaseConnection
 
@@ -185,20 +189,19 @@ abstract class BaseService(
             taskManager.getTasks().forEach { it.cancel() }
             packetManager.disconnect()
             databaseConnection.disconnect()
-            defaultScope.cancel()
-            ioScope.cancel()
+            scope.cancel()
             Console.Companion.CURRENT_CONSOLE?.close(true)
         }
     }
 
     fun sendClusterMessage(message: String, level: Level = Level.INFO, vararg serviceIds: ServiceId) {
-        ioScope.launch {
+        scope.launch {
             packetManager.publish(ClusterMessagePacket(message, level), *serviceIds)
         }
     }
 
     fun sendClusterMessage(message: String, level: Level = Level.INFO, serviceTargetType: ServiceType) {
-        ioScope.launch {
+        scope.launch {
             packetManager.publish(ClusterMessagePacket(message, level), serviceTargetType)
         }
     }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/BaseService.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/BaseService.kt
@@ -129,6 +129,7 @@ abstract class BaseService(
         clusterConfiguration = ClusterConfiguration(databaseConnection)
 
         packetManager = PacketManager(databaseConnection, serviceId)
+        runBlocking { packetManager.connect() }
         eventManager = EventManager("base-event-manager", packetManager)
         val taskThreads = when (serviceId.type) {
             ServiceType.NODE -> 4
@@ -142,12 +143,12 @@ abstract class BaseService(
             .period(30.seconds)
             .register()
 
-        playerRepository = PlayerRepository(databaseConnection, eventManager, packetManager)
-        javaVersionRepository = JavaVersionRepository(serviceId, databaseConnection, packetManager)
-        nodeRepository = NodeRepository(databaseConnection, packetManager, eventManager)
-        serverVersionRepository = CloudServerVersionRepository(databaseConnection, packetManager)
-        configurationTemplateRepository = ConfigurationTemplateRepository(databaseConnection, eventManager, packetManager)
-        serverRepository = ServerRepository(databaseConnection, serviceId, packetManager, eventManager)
+        playerRepository = PlayerRepository(databaseConnection, eventManager, packetManager, scope)
+        javaVersionRepository = JavaVersionRepository(serviceId, databaseConnection, packetManager, scope)
+        nodeRepository = NodeRepository(databaseConnection, packetManager, eventManager, scope)
+        serverVersionRepository = CloudServerVersionRepository(databaseConnection, packetManager, scope)
+        configurationTemplateRepository = ConfigurationTemplateRepository(databaseConnection, eventManager, packetManager, scope)
+        serverRepository = ServerRepository(databaseConnection, serviceId, packetManager, eventManager, scope)
         this.registerPackets()
         this.registerPacketListeners()
     }
@@ -178,7 +179,7 @@ abstract class BaseService(
         this.registerDefaultSuggesters()
     }
 
-    open fun plattformShutdown() {}
+    open fun platformShutdown() {}
 
     open fun shutdown(force: Boolean = false) {
         SHUTTINGDOWN = true
@@ -190,7 +191,7 @@ abstract class BaseService(
             packetManager.disconnect()
             databaseConnection.disconnect()
             scope.cancel()
-            Console.Companion.CURRENT_CONSOLE?.close(true)
+            Console.CURRENT_CONSOLE?.close(true)
         }
     }
 

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ClusterMessagePacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ClusterMessagePacket.kt
@@ -11,7 +11,7 @@ class ClusterMessagePacket(
 ) : AbstractPacket() {
 
     // TODO error support
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         BaseService.LOGGER.log(level, message)
     }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/listener/CloudServiceShutdownPacketListener.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/listener/CloudServiceShutdownPacketListener.kt
@@ -14,7 +14,7 @@ class CloudServiceShutdownPacketListener(baseService: BaseService) : PacketListe
         logger.fine("Received shutdown packet from ${packet.sender}")
         runBlocking {
             packet.respond(CloudServiceShutdownResponse())
-            baseService.plattformShutdown()
+            baseService.platformShutdown()
         }
     }
 )

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/listener/CloudServiceShutdownPacketListener.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/listener/CloudServiceShutdownPacketListener.kt
@@ -5,16 +5,13 @@ import dev.redicloud.logging.LogManager
 import dev.redicloud.service.base.BaseService
 import dev.redicloud.service.base.packets.service.CloudServiceShutdownPacket
 import dev.redicloud.service.base.packets.service.CloudServiceShutdownResponse
-import kotlinx.coroutines.runBlocking
 
 private val logger = LogManager.logger(CloudServiceShutdownPacketListener::class)
 class CloudServiceShutdownPacketListener(baseService: BaseService) : PacketListener<CloudServiceShutdownPacket>(
     CloudServiceShutdownPacket::class,
     { packet ->
         logger.fine("Received shutdown packet from ${packet.sender}")
-        runBlocking {
-            packet.respond(CloudServiceShutdownResponse())
-            baseService.platformShutdown()
-        }
+        packet.respond(CloudServiceShutdownResponse())
+        baseService.platformShutdown()
     }
 )

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ping/ServicePingPacket.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/packets/ping/ServicePingPacket.kt
@@ -2,15 +2,11 @@ package dev.redicloud.service.base.packets.ping
 
 import dev.redicloud.api.packets.AbstractPacket
 import dev.redicloud.api.packets.IPacketManager
-import dev.redicloud.utils.ioScope
-import kotlinx.coroutines.launch
 
 class ServicePingPacket : AbstractPacket() {
-    override fun received(manager: IPacketManager) {
+    override suspend fun received(manager: IPacketManager) {
         super.received(manager)
         val s = System.currentTimeMillis()
-        ioScope.launch {
-            manager.publish(ServicePingResponse(s).asAnswerOf(this@ServicePingPacket), sender!!)
-        }
+        manager.publish(ServicePingResponse(s).asAnswerOf(this), sender!!)
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudNodeParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudNodeParser.kt
@@ -5,22 +5,19 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.isServiceId
 import dev.redicloud.repository.node.CloudNode
 import dev.redicloud.repository.node.NodeRepository
-import kotlinx.coroutines.runBlocking
 
 class CloudNodeParser(private val nodeRepository: NodeRepository) : ICommandArgumentParser<CloudNode> {
 
-    override fun parse(parameter: String): CloudNode? {
-        return runBlocking {
-            try {
-                if (parameter.isServiceId()) {
-                    val serviceId = ServiceId.fromString(parameter)
-                    return@runBlocking nodeRepository.getNode(serviceId)
-                }
-                return@runBlocking nodeRepository.getRegisteredNodes()
-                    .firstOrNull { it.name.lowercase() == parameter.lowercase() }
-            } catch (_: Exception) {
-                return@runBlocking null
+    override suspend fun parse(parameter: String): CloudNode? {
+        try {
+            if (parameter.isServiceId()) {
+                val serviceId = ServiceId.fromString(parameter)
+                return nodeRepository.getNode(serviceId)
             }
+            return nodeRepository.getRegisteredNodes()
+                .firstOrNull { it.name.equals(parameter, ignoreCase = true) }
+        } catch (_: Exception) {
+            return null
         }
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudServerParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudServerParser.kt
@@ -5,22 +5,19 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.isServiceId
 import dev.redicloud.repository.server.CloudServer
 import dev.redicloud.repository.server.ServerRepository
-import kotlinx.coroutines.runBlocking
 
 class CloudServerParser(private val serverRepository: ServerRepository) : ICommandArgumentParser<CloudServer> {
 
-    override fun parse(parameter: String): CloudServer? {
-        return runBlocking {
-            try {
-                if (parameter.isServiceId()) {
-                    val serviceId = ServiceId.fromString(parameter)
-                    return@runBlocking serverRepository.getServer(serviceId)
-                }
-                return@runBlocking serverRepository.getRegisteredServers()
-                    .firstOrNull { it.name.lowercase() == parameter.lowercase() }
-            } catch (_: Exception) {
-                return@runBlocking null
+    override suspend fun parse(parameter: String): CloudServer? {
+        try {
+            if (parameter.isServiceId()) {
+                val serviceId = ServiceId.fromString(parameter)
+                return serverRepository.getServer(serviceId)
             }
+            return serverRepository.getRegisteredServers()
+                .firstOrNull { it.name.equals(parameter, ignoreCase = true) }
+        } catch (_: Exception) {
+            return null
         }
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudServerVersionParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudServerVersionParser.kt
@@ -3,20 +3,17 @@ package dev.redicloud.service.base.parser
 import dev.redicloud.api.commands.ICommandArgumentParser
 import dev.redicloud.repository.server.version.CloudServerVersion
 import dev.redicloud.repository.server.version.CloudServerVersionRepository
-import kotlinx.coroutines.runBlocking
 import java.util.*
 
 class CloudServerVersionParser(private val serverVersionRepository: CloudServerVersionRepository) :
     ICommandArgumentParser<CloudServerVersion> {
 
-    override fun parse(parameter: String): CloudServerVersion? {
-        return runBlocking {
-            try {
-                val uniqueId = UUID.fromString(parameter)
-                serverVersionRepository.getVersion(uniqueId)
-            } catch (_: IllegalArgumentException) {
-                serverVersionRepository.getVersion(parameter)
-            }
+    override suspend fun parse(parameter: String): CloudServerVersion? {
+        return try {
+            val uniqueId = UUID.fromString(parameter)
+            serverVersionRepository.getVersion(uniqueId)
+        } catch (_: IllegalArgumentException) {
+            serverVersionRepository.getVersion(parameter)
         }
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudServerVersionTypeParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/CloudServerVersionTypeParser.kt
@@ -3,15 +3,12 @@ package dev.redicloud.service.base.parser
 import dev.redicloud.api.commands.ICommandArgumentParser
 import dev.redicloud.repository.server.version.CloudServerVersionType
 import dev.redicloud.repository.server.version.CloudServerVersionTypeRepository
-import kotlinx.coroutines.runBlocking
 
 class CloudServerVersionTypeParser(
     private val serverVersionTypeRepository: CloudServerVersionTypeRepository
 ) : ICommandArgumentParser<CloudServerVersionType> {
 
-    override fun parse(parameter: String): CloudServerVersionType? {
-        return runBlocking {
-            serverVersionTypeRepository.getTypes().firstOrNull { it.name.lowercase() == parameter.lowercase() }
-        }
+    override suspend fun parse(parameter: String): CloudServerVersionType? {
+        return serverVersionTypeRepository.getTypes().firstOrNull { it.name.equals(parameter, ignoreCase = true) }
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/ConfigurationTemplateParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/ConfigurationTemplateParser.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.parser
 import dev.redicloud.api.commands.ICommandArgumentParser
 import dev.redicloud.repository.template.configuration.ConfigurationTemplate
 import dev.redicloud.repository.template.configuration.ConfigurationTemplateRepository
-import kotlinx.coroutines.runBlocking
 
 class ConfigurationTemplateParser(
     private val configurationTemplateRepository: ConfigurationTemplateRepository
 ) : ICommandArgumentParser<ConfigurationTemplate> {
 
-    override fun parse(parameter: String): ConfigurationTemplate? =
-        runBlocking { configurationTemplateRepository.getTemplate(parameter) }
+    override suspend fun parse(parameter: String): ConfigurationTemplate? =
+        configurationTemplateRepository.getTemplate(parameter)
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/FileTemplateParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/FileTemplateParser.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.parser
 import dev.redicloud.api.commands.ICommandArgumentParser
 import dev.redicloud.repository.template.file.AbstractFileTemplateRepository
 import dev.redicloud.repository.template.file.FileTemplate
-import kotlinx.coroutines.runBlocking
 
 class FileTemplateParser(
     private val fileTemplateRepository: AbstractFileTemplateRepository
 ) : ICommandArgumentParser<FileTemplate> {
 
-    override fun parse(parameter: String): FileTemplate? =
-        runBlocking { fileTemplateRepository.getTemplate(parameter) }
+    override suspend fun parse(parameter: String): FileTemplate? =
+        fileTemplateRepository.getTemplate(parameter)
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/JavaVersionParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/JavaVersionParser.kt
@@ -3,15 +3,12 @@ package dev.redicloud.service.base.parser
 import dev.redicloud.api.commands.ICommandArgumentParser
 import dev.redicloud.repository.java.version.CloudJavaVersion
 import dev.redicloud.repository.java.version.JavaVersionRepository
-import kotlinx.coroutines.runBlocking
 
 class JavaVersionParser(
     private val javaVersionRepository: JavaVersionRepository
 ) : ICommandArgumentParser<CloudJavaVersion> {
 
-    override fun parse(parameter: String): CloudJavaVersion? {
-        return runBlocking {
-            javaVersionRepository.getVersions().firstOrNull { it.name.lowercase() == parameter.lowercase() }
-        }
+    override suspend fun parse(parameter: String): CloudJavaVersion? {
+        return javaVersionRepository.getVersions().firstOrNull { it.name.equals(parameter, ignoreCase = true) }
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/ServerVersionHandlerParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/ServerVersionHandlerParser.kt
@@ -5,7 +5,7 @@ import dev.redicloud.api.version.IServerVersionHandler
 
 class ServerVersionHandlerParser : ICommandArgumentParser<IServerVersionHandler> {
 
-    override fun parse(parameter: String): IServerVersionHandler? {
-        return IServerVersionHandler.CACHE_HANDLERS.find { it.name.lowercase() == parameter.lowercase() }
+    override suspend fun parse(parameter: String): IServerVersionHandler? {
+        return IServerVersionHandler.CACHE_HANDLERS.find { it.name.equals(parameter, ignoreCase = true) }
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/ServerVersionParser.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/parser/ServerVersionParser.kt
@@ -5,6 +5,6 @@ import dev.redicloud.repository.server.version.serverversion.ServerVersion
 import dev.redicloud.repository.server.version.serverversion.VersionRepository
 
 class ServerVersionParser : ICommandArgumentParser<ServerVersion> {
-    override fun parse(parameter: String): ServerVersion? =
-        VersionRepository.versions().firstOrNull { it.name.lowercase() == parameter.lowercase() }
+    override suspend fun parse(parameter: String): ServerVersion? =
+        VersionRepository.versions().firstOrNull { it.name.equals(parameter, ignoreCase = true) }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/BasePlayerExecutor.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/BasePlayerExecutor.kt
@@ -8,6 +8,7 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.ServiceType
 import dev.redicloud.api.service.server.ICloudServer
 import dev.redicloud.api.service.server.ICloudServerRepository
+import dev.redicloud.logging.LogManager
 import dev.redicloud.service.base.packets.player.*
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.bossbar.BossBar
@@ -235,7 +236,11 @@ abstract class BasePlayerExecutor(
 
     abstract fun audience(player: ICloudPlayer): Audience
 
-    abstract fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer)
+    abstract suspend fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer)
 
-    abstract fun executeKick(cloudPlayer: ICloudPlayer, reason: Component)
+    abstract suspend fun executeKick(cloudPlayer: ICloudPlayer, reason: Component)
+
+    companion object {
+        val LOGGER = LogManager.logger(BasePlayerExecutor::class)
+    }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/PlayerExecutorListener.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/player/PlayerExecutorListener.kt
@@ -4,7 +4,6 @@ import dev.redicloud.api.packets.IPacketManager
 import dev.redicloud.api.packets.listen
 import dev.redicloud.api.player.ICloudPlayerExecutor
 import dev.redicloud.service.base.packets.player.*
-import kotlinx.coroutines.runBlocking
 
 class PlayerExecutorListener(
     private val playerExecutor: ICloudPlayerExecutor,
@@ -12,60 +11,42 @@ class PlayerExecutorListener(
 ) {
 
     val bookPacketListener = packetManager.listen<CloudPlayerBookPacket> {
-        runBlocking {
-            playerExecutor.showBook(it.uniqueId, it.createBook())
-        }
+        playerExecutor.showBook(it.uniqueId, it.createBook())
     }
 
     val bossBarPacketListener = packetManager.listen<CloudPlayerBossBarPacket> {
-        runBlocking {
-            if (it.hide) {
-                playerExecutor.hideBossBar(it.uniqueId, it.createBossBar())
-            } else {
-                playerExecutor.showBossBar(it.uniqueId, it.createBossBar())
-            }
+        if (it.hide) {
+            playerExecutor.hideBossBar(it.uniqueId, it.createBossBar())
+        } else {
+            playerExecutor.showBossBar(it.uniqueId, it.createBossBar())
         }
     }
 
     val connectServerPacketListener = packetManager.listen<CloudPlayerConnectServerPacket> {
-        runBlocking {
-            playerExecutor.connect(it.uniqueId, it.serviceId)
-        }
+        playerExecutor.connect(it.uniqueId, it.serviceId)
     }
 
     val headerFooterPacketListener = packetManager.listen<CloudPlayerHeaderFooterPacket> {
-        runBlocking {
-            playerExecutor.sendPlayerListHeaderAndFooter(it.uniqueId, it.header, it.footer)
-        }
+        playerExecutor.sendPlayerListHeaderAndFooter(it.uniqueId, it.header, it.footer)
     }
 
     val kickPacketListener = packetManager.listen<CloudPlayerKickPacket> {
-        runBlocking {
-            playerExecutor.kick(it.uniqueId, it.reason)
-        }
+        playerExecutor.kick(it.uniqueId, it.reason)
     }
 
     val messagePacketLister = packetManager.listen<CloudPlayerMessagePacket> {
-        runBlocking {
-            playerExecutor.sendMessage(it.uniqueId, it.component)
-        }
+        playerExecutor.sendMessage(it.uniqueId, it.component)
     }
 
     val resourcePacketListener = packetManager.listen<CloudPlayerResourcePackPacket> {
-        runBlocking {
-            playerExecutor.sendResourcePacks(it.uniqueId, it.createResourcePackRequest())
-        }
+        playerExecutor.sendResourcePacks(it.uniqueId, it.createResourcePackRequest())
     }
 
     val soundPacketListener = packetManager.listen<CloudPlayerSoundPacket> {
-        runBlocking {
-            playerExecutor.playSound(it.uniqueId, it.createSound())
-        }
+        playerExecutor.playSound(it.uniqueId, it.createSound())
     }
 
     val titlePacketListener = packetManager.listen<CloudPlayerTitlePacket> {
-        runBlocking {
-            playerExecutor.showTitle(it.uniqueId, it.createTitle())
-        }
+        playerExecutor.showTitle(it.uniqueId, it.createTitle())
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/repository/BaseFileTemplateRepository.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/repository/BaseFileTemplateRepository.kt
@@ -7,12 +7,14 @@ import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.node.NodeRepository
 import dev.redicloud.repository.template.file.AbstractFileTemplateRepository
 import dev.redicloud.repository.template.file.FileTemplate
+import kotlinx.coroutines.CoroutineScope
 
 class BaseFileTemplateRepository(
     databaseConnection: DatabaseConnection,
     nodeRepository: NodeRepository,
-    packetManager: PacketManager
-) : AbstractFileTemplateRepository(databaseConnection, nodeRepository, packetManager) {
+    packetManager: PacketManager,
+    scope: CoroutineScope
+) : AbstractFileTemplateRepository(databaseConnection, nodeRepository, packetManager, scope) {
 
     override suspend fun pushTemplates(serviceId: ServiceId) {
         TODO("Not yet implemented")

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudConnectorFileNameSelector.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudConnectorFileNameSelector.kt
@@ -6,7 +6,7 @@ import dev.redicloud.api.utils.CONNECTORS_FOLDER
 
 class CloudConnectorFileNameSelector : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
+    override suspend fun suggest(context: CommandContext): Array<String> {
         return CONNECTORS_FOLDER.getFile().listFiles()?.map { it.name }?.toTypedArray() ?: arrayOf()
     }
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudServerSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudServerSuggester.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.server.ServerRepository
-import kotlinx.coroutines.runBlocking
 
 class CloudServerSuggester(
     private val serverRepository: ServerRepository
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking { serverRepository.getRegisteredServers().map { it.name }.toTypedArray() }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        serverRepository.getRegisteredServers().map { it.name }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudServerVersionSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudServerVersionSuggester.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.server.version.CloudServerVersionRepository
-import kotlinx.coroutines.runBlocking
 
 class CloudServerVersionSuggester(
     private val cloudServerVersionRepository: CloudServerVersionRepository
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking { cloudServerVersionRepository.getVersions().map { it.displayName }.toTypedArray() }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        cloudServerVersionRepository.getVersions().map { it.displayName }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudServerVersionTypeSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/CloudServerVersionTypeSuggester.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.server.version.CloudServerVersionTypeRepository
-import kotlinx.coroutines.runBlocking
 
 class CloudServerVersionTypeSuggester(
     private val serverVersionTypeRepository: CloudServerVersionTypeRepository
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking { serverVersionTypeRepository.getTypes().filter { !it.isUnknown() }.map { it.name }.toTypedArray() }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        serverVersionTypeRepository.getTypes().filter { !it.isUnknown() }.map { it.name }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ConfigurationTemplateSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ConfigurationTemplateSuggester.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.template.configuration.ConfigurationTemplateRepository
-import kotlinx.coroutines.runBlocking
 
 class ConfigurationTemplateSuggester(
     private val configurationTemplateRepository: ConfigurationTemplateRepository
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking { configurationTemplateRepository.getTemplates().map { it.name }.toTypedArray() }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        configurationTemplateRepository.getTemplates().map { it.name }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ConnectedCloudNodeSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ConnectedCloudNodeSuggester.kt
@@ -3,10 +3,9 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.node.NodeRepository
-import kotlinx.coroutines.runBlocking
 
 class ConnectedCloudNodeSuggester(private val nodeRepository: NodeRepository) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking { nodeRepository.getConnectedNodes().map { it.name }.toTypedArray() }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        nodeRepository.getConnectedNodes().map { it.name }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/FileTemplateSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/FileTemplateSuggester.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.template.file.AbstractFileTemplateRepository
-import kotlinx.coroutines.runBlocking
 
 class FileTemplateSuggester(
     private val fileTemplateRepository: AbstractFileTemplateRepository
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking { fileTemplateRepository.getTemplates().map { it.displayName }.toTypedArray() }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        fileTemplateRepository.getTemplates().map { it.displayName }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/JavaVersionSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/JavaVersionSuggester.kt
@@ -3,14 +3,11 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.java.version.JavaVersionRepository
-import kotlinx.coroutines.runBlocking
 
 class JavaVersionSuggester(
     private val javaVersionRepository: JavaVersionRepository
 ) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking {
-            javaVersionRepository.getVersions().map { it.name }.toTypedArray()
-        }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        javaVersionRepository.getVersions().map { it.name }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/RegisteredCloudNodeSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/RegisteredCloudNodeSuggester.kt
@@ -3,10 +3,9 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.node.NodeRepository
-import kotlinx.coroutines.runBlocking
 
 class RegisteredCloudNodeSuggester(private val nodeRepository: NodeRepository) : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
-        runBlocking { nodeRepository.getRegisteredNodes().map { it.name }.toTypedArray() }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        nodeRepository.getRegisteredNodes().map { it.name }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ServerVersionHandlerSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ServerVersionHandlerSuggester.kt
@@ -6,6 +6,6 @@ import dev.redicloud.api.version.IServerVersionHandler
 
 class ServerVersionHandlerSuggester : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> =
+    override suspend fun suggest(context: CommandContext): Array<String> =
         IServerVersionHandler.CACHE_HANDLERS.map { it.name }.toTypedArray()
 }

--- a/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ServerVersionSuggester.kt
+++ b/services/base-service/src/main/kotlin/dev/redicloud/service/base/suggester/ServerVersionSuggester.kt
@@ -3,12 +3,11 @@ package dev.redicloud.service.base.suggester
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.repository.server.version.serverversion.VersionRepository
-import kotlinx.coroutines.runBlocking
 
 class ServerVersionSuggester : AbstractCommandSuggester() {
 
-    override fun suggest(context: CommandContext): Array<String> {
-        runBlocking { VersionRepository.loadIfNotLoaded() }
+    override suspend fun suggest(context: CommandContext): Array<String> {
+        VersionRepository.loadIfNotLoaded()
         return VersionRepository.versions().map { it.name }.toTypedArray()
     }
 }

--- a/services/minecraft-server-service/src/main/kotlin/dev/redicloud/service/minecraft/MinecraftServerService.kt
+++ b/services/minecraft-server-service/src/main/kotlin/dev/redicloud/service/minecraft/MinecraftServerService.kt
@@ -42,34 +42,38 @@ abstract class MinecraftServerService<T> :
         BaseFileTemplateRepository(this.databaseConnection, this.nodeRepository, packetManager)
     override val serverVersionTypeRepository: CloudServerVersionTypeRepository =
         CloudServerVersionTypeRepository(this.databaseConnection, null, packetManager)
-    val currentServerData: CurrentServerData = runBlocking {
-        CurrentServerData(
-            getServer().serviceId,
-            getServer().name,
-            getServer().id,
-            getServer().maxPlayers,
-            getServer().connectedPlayers,
-            getServer().state,
-            getServer().configurationTemplate.name,
-            getVersion().displayName
-        )
-    }
-    private val hostServiceId: ServiceId = runBlocking { serverRepository.connect(serviceId) }
-    override val moduleHandler: ModuleHandler =
-        ModuleHandler(
-            serviceId,
-            loadModuleRepositoryUrls(),
-            eventManager,
-            packetManager,
-            runBlocking { getVersionType() },
-            databaseConnection
-        )
+    lateinit var currentServerData: CurrentServerData
+        private set
+    private lateinit var hostServiceId: ServiceId
+    private lateinit var _moduleHandler: ModuleHandler
+    override val moduleHandler: ModuleHandler get() = _moduleHandler
     abstract val screenProvider: AbstractScreenProvider
     val remoteServerFactory: RemoteServerFactory =
         RemoteServerFactory(this.databaseConnection, this.nodeRepository, this.serverRepository)
 
-    init {
-        runBlocking { packetManager.registerCategoryChannel(currentServerData.configurationTemplateName) }
+    open suspend fun start() {
+        val server = getServer()
+        val version = getVersion()
+        currentServerData = CurrentServerData(
+            server.serviceId,
+            server.name,
+            server.id,
+            server.maxPlayers,
+            server.connectedPlayers,
+            server.state,
+            server.configurationTemplate.name,
+            version.displayName
+        )
+        hostServiceId = serverRepository.connect(serviceId)
+        _moduleHandler = ModuleHandler(
+            serviceId,
+            loadModuleRepositoryUrls(),
+            eventManager,
+            packetManager,
+            getVersionType(),
+            databaseConnection
+        )
+        packetManager.registerCategoryChannel(currentServerData.configurationTemplateName)
         registerDefaults()
     }
 

--- a/services/minecraft-server-service/src/main/kotlin/dev/redicloud/service/minecraft/MinecraftServerService.kt
+++ b/services/minecraft-server-service/src/main/kotlin/dev/redicloud/service/minecraft/MinecraftServerService.kt
@@ -39,9 +39,9 @@ abstract class MinecraftServerService<T> :
     }
 
     override val fileTemplateRepository: AbstractFileTemplateRepository =
-        BaseFileTemplateRepository(this.databaseConnection, this.nodeRepository, packetManager)
+        BaseFileTemplateRepository(this.databaseConnection, this.nodeRepository, packetManager, scope)
     override val serverVersionTypeRepository: CloudServerVersionTypeRepository =
-        CloudServerVersionTypeRepository(this.databaseConnection, null, packetManager)
+        CloudServerVersionTypeRepository(this.databaseConnection, null, packetManager, scope)
     lateinit var currentServerData: CurrentServerData
         private set
     private lateinit var hostServiceId: ServiceId

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
@@ -76,49 +76,49 @@ class NodeService(
         )
         moduleHandler = ModuleHandler(serviceId, loadModuleRepositoryUrls(), eventManager, packetManager, null, databaseConnection)
         playerExecutor = NodePlayerExecutor(this.playerRepository, serverRepository, packetManager, serviceId)
+    }
 
-        runBlocking {
-            registerDefaults()
-            this@NodeService.initShutdownHook()
+    suspend fun start() {
+        registerDefaults()
+        initShutdownHook()
 
-            Updater.check()
+        Updater.check()
 
-            nodeRepository.connect(this@NodeService)
-            @Suppress("TooGenericExceptionCaught")
-            try { memoryCheck() } catch (e: Exception) {
-                LOGGER.severe("Error while checking memory", e)
-                shutdown()
-                return@runBlocking
-            }
-
-            @Suppress("TooGenericExceptionCaught")
-            try { this@NodeService.checkJavaVersions() } catch (e: Exception) {
-                LOGGER.warning("Error while checking java versions", e)
-            }
-
-            Updater.registerSuggesters(console.commandManager)
-
-            IServerVersionHandler.registerHandler(
-                URLServerVersionHandler(
-                    serviceId,
-                    serverVersionRepository,
-                    serverVersionTypeRepository,
-                    nodeRepository,
-                    console,
-                    javaVersionRepository
-                )
-            )
-
-            this@NodeService.registerPreTasks()
-            this@NodeService.connectFileCluster()
-            this@NodeService.registerPackets()
-            this@NodeService.registerCommands()
-            this@NodeService.registerTasks()
-            this@NodeService.registerListeners()
-
-            initApi()
-            moduleHandler.loadModules()
+        nodeRepository.connect(this)
+        @Suppress("TooGenericExceptionCaught")
+        try { memoryCheck() } catch (e: Exception) {
+            LOGGER.severe("Error while checking memory", e)
+            shutdown()
+            return
         }
+
+        @Suppress("TooGenericExceptionCaught")
+        try { checkJavaVersions() } catch (e: Exception) {
+            LOGGER.warning("Error while checking java versions", e)
+        }
+
+        Updater.registerSuggesters(console.commandManager)
+
+        IServerVersionHandler.registerHandler(
+            URLServerVersionHandler(
+                serviceId,
+                serverVersionRepository,
+                serverVersionTypeRepository,
+                nodeRepository,
+                console,
+                javaVersionRepository
+            )
+        )
+
+        registerPreTasks()
+        connectFileCluster()
+        registerPackets()
+        registerCommands()
+        registerTasks()
+        registerListeners()
+
+        initApi()
+        moduleHandler.loadModules()
     }
 
     private fun registerListeners() {

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
@@ -72,7 +72,7 @@ class NodeService(
             fileTemplateRepository, javaVersionRepository,
             packetManager, configuration.hostAddress, console,
             clusterConfiguration, configurationTemplateRepository,
-            eventManager, fileCluster
+            eventManager, fileCluster, scope
         )
         moduleHandler = ModuleHandler(serviceId, loadModuleRepositoryUrls(), eventManager, packetManager, null, databaseConnection)
         playerExecutor = NodePlayerExecutor(this.playerRepository, serverRepository, packetManager, serviceId)

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
@@ -62,10 +62,10 @@ class NodeService(
 
     init {
         console = NodeConsole(configuration, eventManager, nodeRepository, serverRepository)
-        fileNodeRepository = FileNodeRepository(databaseConnection, packetManager)
+        fileNodeRepository = FileNodeRepository(databaseConnection, packetManager, scope)
         fileCluster = FileCluster(serviceId, configuration.hostAddress, fileNodeRepository, packetManager, nodeRepository, eventManager)
-        fileTemplateRepository = NodeFileTemplateRepository(databaseConnection, nodeRepository, fileCluster, packetManager)
-        serverVersionTypeRepository = CloudServerVersionTypeRepository(databaseConnection, console, packetManager)
+        fileTemplateRepository = NodeFileTemplateRepository(databaseConnection, nodeRepository, fileCluster, packetManager, scope)
+        serverVersionTypeRepository = CloudServerVersionTypeRepository(databaseConnection, console, packetManager, scope)
         serverFactory = ServerFactory(
             databaseConnection, nodeRepository, serverRepository,
             serverVersionRepository, serverVersionTypeRepository,
@@ -131,8 +131,8 @@ class NodeService(
         )
     }
 
-    override fun plattformShutdown() {
-        super.plattformShutdown()
+    override fun platformShutdown() {
+        super.platformShutdown()
         shutdown(false)
     }
 

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
@@ -5,12 +5,13 @@ import dev.redicloud.service.node.NodeService
 import dev.redicloud.service.node.console.InitializeConsole
 import dev.redicloud.utils.loadProperties
 import dev.redicloud.utils.threadLogger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("TooGenericExceptionCaught")
 fun main(args: Array<String>) {
     println("Starting node service...")
     Thread.sleep(500)
@@ -18,15 +19,17 @@ fun main(args: Array<String>) {
         threadLogger.severe("Caught exception in thread: ${thread.name}", throwable)
     }
     runBlocking {
-        runCatching {
+        try {
             loadProperties(Thread.currentThread().contextClassLoader)
             val preConsole = InitializeConsole()
             val databaseConnection = preConsole.databaseConnection!!
             val databaseConfiguration = preConsole.databaseConfiguration!!
             val nodeConfiguration = preConsole.nodeConfiguration!!
             NodeService(databaseConfiguration, databaseConnection, nodeConfiguration, preConsole.firstStartDetected)
-        }.onFailure {
-            LogManager.rootLogger().severe("Failed to start node service!", it)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LogManager.rootLogger().severe("Failed to start node service!", e)
             delay(1.seconds)
             exitProcess(1)
         }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
@@ -5,15 +5,15 @@ import dev.redicloud.service.node.NodeService
 import dev.redicloud.service.node.console.InitializeConsole
 import dev.redicloud.utils.loadProperties
 import dev.redicloud.utils.threadLogger
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
-
-private const val STARTUP_DELAY_MS = 500L
-private const val FAILURE_RETRY_DELAY_MS = 1000L
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 fun main(args: Array<String>) {
     println("Starting node service...")
-    Thread.sleep(STARTUP_DELAY_MS)
+    Thread.sleep(500)
     Thread.currentThread().setUncaughtExceptionHandler { thread, throwable ->
         threadLogger.severe("Caught exception in thread: ${thread.name}", throwable)
     }
@@ -27,7 +27,7 @@ fun main(args: Array<String>) {
             NodeService(databaseConfiguration, databaseConnection, nodeConfiguration, preConsole.firstStartDetected)
         }.onFailure {
             LogManager.rootLogger().severe("Failed to start node service!", it)
-            Thread.sleep(FAILURE_RETRY_DELAY_MS)
+            delay(1.seconds)
             exitProcess(1)
         }
     }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
@@ -28,7 +28,12 @@ fun main(args: Array<String>) {
             val databaseConnection = preConsole.databaseConnection!!
             val databaseConfiguration = preConsole.databaseConfiguration!!
             val nodeConfiguration = preConsole.nodeConfiguration!!
-            val nodeService = NodeService(databaseConfiguration, databaseConnection, nodeConfiguration, preConsole.firstStartDetected)
+            val nodeService = NodeService(
+                databaseConfiguration,
+                databaseConnection,
+                nodeConfiguration,
+                preConsole.firstStartDetected
+            )
             nodeService.start()
         } catch (e: CancellationException) {
             throw e

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
@@ -28,7 +28,8 @@ fun main(args: Array<String>) {
             val databaseConnection = preConsole.databaseConnection!!
             val databaseConfiguration = preConsole.databaseConfiguration!!
             val nodeConfiguration = preConsole.nodeConfiguration!!
-            NodeService(databaseConfiguration, databaseConnection, nodeConfiguration, preConsole.firstStartDetected)
+            val nodeService = NodeService(databaseConfiguration, databaseConnection, nodeConfiguration, preConsole.firstStartDetected)
+            nodeService.start()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/bootstrap/NodeBootstrap.kt
@@ -9,12 +9,15 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+
+private val STARTUP_DELAY = 500.milliseconds
 
 @Suppress("TooGenericExceptionCaught")
 fun main(args: Array<String>) {
     println("Starting node service...")
-    Thread.sleep(500)
+    Thread.sleep(STARTUP_DELAY.inWholeMilliseconds)
     Thread.currentThread().setUncaughtExceptionHandler { thread, throwable ->
         threadLogger.severe("Caught exception in thread: ${thread.name}", throwable)
     }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/CloudServerVersionCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/CloudServerVersionCommand.kt
@@ -16,11 +16,9 @@ import dev.redicloud.repository.server.version.serverversion.ServerVersion
 import dev.redicloud.repository.template.configuration.ConfigurationTemplateRepository
 import dev.redicloud.service.base.suggester.*
 import dev.redicloud.service.node.repository.node.LOGGER
-import dev.redicloud.utils.defaultScope
 import dev.redicloud.utils.fileName
 import dev.redicloud.utils.isValidUrl
 import dev.redicloud.utils.toSymbol
-import kotlinx.coroutines.launch
 import java.net.URL
 import java.util.*
 
@@ -38,15 +36,15 @@ class CloudServerVersionCommand(
 
     @CommandSubPath("duplicate <version> [new-name]")
     @CommandDescription("Duplicate a server version")
-    fun duplicate(
+    suspend fun duplicate(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("newName", false) newName: String?
-    ) = defaultScope.launch {
+    ) {
         val newVersion = version.copy(newName ?: "${version.projectName}_copy")
         if (serverVersionRepository.existsVersion(newVersion.displayName)) {
             actor.sendMessage("§cA version with the name '${newVersion.displayName}' already exists!")
-            return@launch
+            return
         }
         serverVersionRepository.createVersion(newVersion)
         actor.sendMessage(
@@ -58,167 +56,157 @@ class CloudServerVersionCommand(
 
     @CommandSubPath("edit <version> project <name>")
     @CommandDescription("Set the project name of the server version")
-    fun onEditName(
+    suspend fun onEditName(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("name", true) name: String
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            if (serverVersionRepository.existsVersion(name)) {
-                actor.sendMessage("§cA version with the name '$name' already exists!")
-                return@launch
-            }
-            val oldName = version.projectName
-            version.projectName = name
-            serverVersionRepository.updateVersion(version)
-            actor.sendMessage("Updated project name of $oldName to ${version.projectName}")
+        if (version.online) {
+            actor.sendMessage(
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
+            )
+            return
         }
+        if (serverVersionRepository.existsVersion(name)) {
+            actor.sendMessage("§cA version with the name '$name' already exists!")
+            return
+        }
+        val oldName = version.projectName
+        version.projectName = name
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage("Updated project name of $oldName to ${version.projectName}")
     }
 
     @CommandSubPath("edit <version> url <url>")
     @CommandDescription("Set the download url of the server version")
-    fun onEditUrl(
+    suspend fun onEditUrl(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("url", true) url: String
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            if (url != "null" && !isValidUrl(url)) {
-                actor.sendMessage("§cThe url '$url' is not valid!")
-                return@launch
-            }
-            version.customDownloadUrl = if (url != "null") url else null
-            serverVersionRepository.updateVersion(version)
+        if (version.online) {
             actor.sendMessage(
-                "Updated download url of ${toConsoleValue(version.displayName)} to ${toConsoleValue(url)}"
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
             )
+            return
         }
+        if (url != "null" && !isValidUrl(url)) {
+            actor.sendMessage("§cThe url '$url' is not valid!")
+            return
+        }
+        version.customDownloadUrl = if (url != "null") url else null
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage(
+            "Updated download url of ${toConsoleValue(version.displayName)} to ${toConsoleValue(url)}"
+        )
     }
 
     @CommandSubPath("edit <version> type <type>")
     @CommandDescription("Set the type of the server version")
-    fun onEditType(
+    suspend fun onEditType(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("type", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            if (version.version.versionTypes.isNotEmpty() &&
-                version.version.versionTypes.none { it.lowercase() == type.name.lowercase() } &&
-                version.version.versionTypes.filter { it.startsWith("!") }
-                    .any { it.replaceFirst("!", "").lowercase() == type.name.lowercase() }
-            ) {
-                actor.sendMessage(
-                    "§cThe type ${
-                        toConsoleValue(
-                            type.name,
-                            false
-                        )
-                    } is not supported by the version ${toConsoleValue(version.version.name, false)}"
-                )
-                return@launch
-            }
-            version.typeId = type.uniqueId
-            serverVersionRepository.updateVersion(version)
-            actor.sendMessage("Updated type of ${toConsoleValue(version.displayName)} to ${toConsoleValue(type.name)}")
+        if (version.online) {
+            actor.sendMessage(
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
+            )
+            return
         }
+        if (version.version.versionTypes.isNotEmpty() &&
+            version.version.versionTypes.none { it.lowercase() == type.name.lowercase() } &&
+            version.version.versionTypes.filter { it.startsWith("!") }
+                .any { it.replaceFirst("!", "").lowercase() == type.name.lowercase() }
+        ) {
+            actor.sendMessage(
+                "§cThe type ${
+                    toConsoleValue(
+                        type.name,
+                        false
+                    )
+                } is not supported by the version ${toConsoleValue(version.version.name, false)}"
+            )
+            return
+        }
+        version.typeId = type.uniqueId
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage("Updated type of ${toConsoleValue(version.displayName)} to ${toConsoleValue(type.name)}")
     }
 
     @CommandSubPath("edit <version> libPattern <pattern>")
     @CommandDescription(
         "Set the lib pattern for the files that should be stored after the patch. Set to 'null' to disable the patching"
     )
-    fun onEditLibPattern(
+    suspend fun onEditLibPattern(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("pattern", true) pattern: String
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            version.libPattern = if (pattern != "null") pattern else null
-            serverVersionRepository.updateVersion(version)
+        if (version.online) {
             actor.sendMessage(
-                "Updated lib pattern of ${toConsoleValue(version.displayName)} to §8'%tc%${version.libPattern}§8'"
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
             )
+            return
         }
+        version.libPattern = if (pattern != "null") pattern else null
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage(
+            "Updated lib pattern of ${toConsoleValue(version.displayName)} to §8'%tc%${version.libPattern}§8'"
+        )
     }
 
     @CommandSubPath("edit <version> patch <state>")
     @CommandDescription("Enable or disable the patching of the server version")
-    fun onEditPatch(
+    suspend fun onEditPatch(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("state", true, BooleanSuggester::class) state: Boolean
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            version.patch = state
-            serverVersionRepository.updateVersion(version)
-            actor.sendMessage("Updated patching of ${toConsoleValue(version.displayName)} to ${toConsoleValue(state)}")
+        if (version.online) {
+            actor.sendMessage(
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
+            )
+            return
         }
+        version.patch = state
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage("Updated patching of ${toConsoleValue(version.displayName)} to ${toConsoleValue(state)}")
     }
 
     @CommandSubPath("edit <version> javaversion <java>")
     @CommandAlias(["edit <version> jv <java>", "edit <version> java <java>"])
     @CommandDescription("Edit the Java version of a server version")
-    fun editJavaVersion(
+    suspend fun editJavaVersion(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionSuggester::class) serverVersion: CloudServerVersion,
         @CommandParameter("java", true, JavaVersionSuggester::class) version: CloudJavaVersion
-    ) = defaultScope.launch {
+    ) {
         serverVersion.javaVersionId = version.uniqueId
         serverVersionRepository.updateVersion(serverVersion)
         actor.sendMessage(
@@ -232,504 +220,474 @@ class CloudServerVersionCommand(
 
     @CommandSubPath("edit <version> version <mcversion>")
     @CommandDescription("Set the minecraft version of the server version")
-    fun onEditMinecraftVersion(
+    suspend fun onEditMinecraftVersion(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("mcversion", true, ServerVersionSuggester::class) minecraftVersion: ServerVersion
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            version.version = minecraftVersion
-            serverVersionRepository.updateVersion(version)
+        if (version.online) {
             actor.sendMessage(
-                "Updated minecraft version of ${toConsoleValue(version.displayName)} to ${
+                "§cThe version ${
                     toConsoleValue(
-                        minecraftVersion.name
+                        version.displayName,
+                        false
                     )
-                }"
+                } is online and can't be edited!"
             )
+            return
         }
+        version.version = minecraftVersion
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage(
+            "Updated minecraft version of ${toConsoleValue(version.displayName)} to ${
+                toConsoleValue(
+                    minecraftVersion.name
+                )
+            }"
+        )
     }
 
     @CommandSubPath("edit <name> jvmargument add <argument>")
     @CommandAlias(["edit <name> jvmarg add <argument>"])
     @CommandDescription("Add a jvm argument to the server version")
-    fun addJvmArgument(
+    suspend fun addJvmArgument(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionSuggester::class) type: CloudServerVersion,
         @CommandParameter("argument") argument: String
     ) {
-        defaultScope.launch {
-            type.jvmArguments.add(argument)
-            serverVersionRepository.updateVersion(type)
-            actor.sendMessage(
-                "The JVM argument ${toConsoleValue(argument)} was added to the server version ${
-                    toConsoleValue(
-                        type.displayName
-                    )
-                }!"
-            )
-        }
+        type.jvmArguments.add(argument)
+        serverVersionRepository.updateVersion(type)
+        actor.sendMessage(
+            "The JVM argument ${toConsoleValue(argument)} was added to the server version ${
+                toConsoleValue(
+                    type.displayName
+                )
+            }!"
+        )
     }
 
     @CommandSubPath("edit <name> jvmargument remove <argument>")
     @CommandAlias(["edit <name> jvmarg remove <argument>"])
     @CommandDescription("Remove a jvm argument from the server version")
-    fun removeJvmArgument(
+    suspend fun removeJvmArgument(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionSuggester::class) type: CloudServerVersion,
         @CommandParameter("argument") argument: String
     ) {
-        defaultScope.launch {
-            type.jvmArguments.remove(argument)
-            serverVersionRepository.updateVersion(type)
-            actor.sendMessage(
-                "The JVM argument ${toConsoleValue(argument)} was removed from the server version ${
-                    toConsoleValue(
-                        type.displayName
-                    )
-                }!"
-            )
-        }
+        type.jvmArguments.remove(argument)
+        serverVersionRepository.updateVersion(type)
+        actor.sendMessage(
+            "The JVM argument ${toConsoleValue(argument)} was removed from the server version ${
+                toConsoleValue(
+                    type.displayName
+                )
+            }!"
+        )
     }
 
     @CommandSubPath("edit <name> fileedits add <file> <key>")
     @CommandAlias(["edit <name> fe add <file> <key>"])
     @CommandDescription("Add a file edit that should be applied before the server is starts")
-    fun addFileEdit(
+    suspend fun addFileEdit(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("file") file: String,
         @CommandParameter("key") key: String,
         @CommandParameter("value") value: String
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            val subMap = version.fileEdits.getOrDefault(file, mutableMapOf())
-            subMap[key] = value
-            version.fileEdits[file] = subMap
-            serverVersionRepository.updateVersion(version)
-            actor.sendMessage("Successfully added file edit to server version type!")
+        if (version.online) {
+            actor.sendMessage(
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
+            )
+            return
         }
+        val subMap = version.fileEdits.getOrDefault(file, mutableMapOf())
+        subMap[key] = value
+        version.fileEdits[file] = subMap
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage("Successfully added file edit to server version type!")
     }
 
     @CommandSubPath("edit <name> fileedits remove <file> <key>")
     @CommandAlias(["edit <name> fe remove <file> <key>"])
     @CommandDescription("Remove a file edit that should be applied before the server is starts")
-    fun removeFileEdit(
+    suspend fun removeFileEdit(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("file") file: String,
         @CommandParameter("key") key: String
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            val subMap = version.fileEdits.getOrDefault(file, mutableMapOf())
-            subMap.remove(key)
-            if (subMap.isEmpty()) {
-                version.fileEdits.remove(file)
-            } else {
-                version.fileEdits[file] = subMap
-            }
-            serverVersionRepository.updateVersion(version)
-            actor.sendMessage("Successfully removed file edit from server version type!")
+        if (version.online) {
+            actor.sendMessage(
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
+            )
+            return
         }
+        val subMap = version.fileEdits.getOrDefault(file, mutableMapOf())
+        subMap.remove(key)
+        if (subMap.isEmpty()) {
+            version.fileEdits.remove(file)
+        } else {
+            version.fileEdits[file] = subMap
+        }
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage("Successfully removed file edit from server version type!")
     }
 
     @CommandSubPath("edit <version> files add <url> [path]")
     @CommandDescription("Add a file to the server version that will be downloaded")
-    fun onEditFilesAdd(
+    suspend fun onEditFilesAdd(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("url") url: String,
         @CommandParameter("path", false) path: String?
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            if (!isValidUrl(url)) {
-                actor.sendMessage("§cThe url '$url' is not valid!")
-                return@launch
-            }
-            val file = path ?: URL(url).fileName
-            if (version.defaultFiles.any { it.value.lowercase() == file.lowercase() }) {
-                actor.sendMessage(
-                    "§cThe file with the url '$url' is already added to the version ${
-                        toConsoleValue(
-                            version.displayName
-                        )
-                    }!"
-                )
-                return@launch
-            }
-            version.defaultFiles[url] = file
-            serverVersionRepository.updateVersion(version)
-            actor.sendMessage("Added file with url ${toConsoleValue(url)} to ${toConsoleValue(version.displayName)}")
+        if (version.online) {
+            actor.sendMessage(
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
+            )
+            return
         }
+        if (!isValidUrl(url)) {
+            actor.sendMessage("§cThe url '$url' is not valid!")
+            return
+        }
+        val file = path ?: URL(url).fileName
+        if (version.defaultFiles.any { it.value.lowercase() == file.lowercase() }) {
+            actor.sendMessage(
+                "§cThe file with the url '$url' is already added to the version ${
+                    toConsoleValue(
+                        version.displayName
+                    )
+                }!"
+            )
+            return
+        }
+        version.defaultFiles[url] = file
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage("Added file with url ${toConsoleValue(url)} to ${toConsoleValue(version.displayName)}")
     }
 
     @CommandSubPath("edit <version> files remove <url>")
     @CommandDescription("Remove a file from the server version that will be downloaded")
-    fun onEditFilesRemove(
+    suspend fun onEditFilesRemove(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("url") url: String
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            if (version.defaultFiles.none { it.value.lowercase() == url.lowercase() }) {
-                actor.sendMessage(
-                    "§cThe file with the url '$url' is not added to the version ${toConsoleValue(version.displayName)}!"
-                )
-                return@launch
-            }
-            version.defaultFiles.remove(url)
-            serverVersionRepository.updateVersion(version)
+        if (version.online) {
             actor.sendMessage(
-                "Removed file with url ${toConsoleValue(url)} from ${toConsoleValue(version.displayName)}"
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
             )
+            return
         }
+        if (version.defaultFiles.none { it.value.lowercase() == url.lowercase() }) {
+            actor.sendMessage(
+                "§cThe file with the url '$url' is not added to the version ${toConsoleValue(version.displayName)}!"
+            )
+            return
+        }
+        version.defaultFiles.remove(url)
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage(
+            "Removed file with url ${toConsoleValue(url)} from ${toConsoleValue(version.displayName)}"
+        )
     }
 
     @CommandSubPath("edit <name> programparameter add <parameter>")
     @CommandDescription("Add a program parameter to the version")
-    fun addProgramParameter(
+    suspend fun addProgramParameter(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("parameter") parameter: String
     ) {
-        defaultScope.launch {
-            if (version.programParameters.contains(parameter)) {
-                actor.sendMessage(
-                    "§cThe program parameter '$parameter' is already added to the version ${
-                        toConsoleValue(
-                            version.displayName
-                        )
-                    }!"
-                )
-                return@launch
-            }
-            version.programParameters.add(parameter)
-            serverVersionRepository.updateVersion(version)
+        if (version.programParameters.contains(parameter)) {
             actor.sendMessage(
-                "Added program parameter ${toConsoleValue(parameter)} to ${toConsoleValue(version.displayName)}"
+                "§cThe program parameter '$parameter' is already added to the version ${
+                    toConsoleValue(
+                        version.displayName
+                    )
+                }!"
             )
+            return
         }
+        version.programParameters.add(parameter)
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage(
+            "Added program parameter ${toConsoleValue(parameter)} to ${toConsoleValue(version.displayName)}"
+        )
     }
 
     @CommandSubPath("edit <name> programparameter remove <parameter>")
     @CommandDescription("Remove a program parameter from the version")
-    fun removeProgramParameter(
+    suspend fun removeProgramParameter(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionSuggester::class) version: CloudServerVersion,
         @CommandParameter("parameter") parameter: String
     ) {
-        defaultScope.launch {
-            if (!version.programParameters.contains(parameter)) {
-                actor.sendMessage(
-                    "§cThe program parameter '$parameter' is not added to the version ${
-                        toConsoleValue(
-                            version.displayName
-                        )
-                    }!"
-                )
-                return@launch
-            }
-            version.programParameters.remove(parameter)
-            serverVersionRepository.updateVersion(version)
+        if (!version.programParameters.contains(parameter)) {
             actor.sendMessage(
-                "Removed program parameter ${toConsoleValue(parameter)} from ${toConsoleValue(version.displayName)}"
+                "§cThe program parameter '$parameter' is not added to the version ${
+                    toConsoleValue(
+                        version.displayName
+                    )
+                }!"
             )
+            return
         }
+        version.programParameters.remove(parameter)
+        serverVersionRepository.updateVersion(version)
+        actor.sendMessage(
+            "Removed program parameter ${toConsoleValue(parameter)} from ${toConsoleValue(version.displayName)}"
+        )
     }
 
     @CommandSubPath("create <project> <version>")
     @CommandDescription("Create a new server version")
-    fun onCreate(
+    suspend fun onCreate(
         actor: ConsoleActor,
         @CommandParameter("project", true) projectName: String,
         @CommandParameter("version", true, ServerVersionSuggester::class) mcVersion: ServerVersion
     ) {
-        defaultScope.launch {
-            val version = CloudServerVersion(
-                UUID.randomUUID(),
-                CloudServerVersionTypeRepository.DEFAULT_TYPES_CACHE.get()!!.first { it.name == "unknown" }.uniqueId,
-                projectName,
-                null,
-                null,
-                mcVersion,
-                null,
+        val version = CloudServerVersion(
+            UUID.randomUUID(),
+            CloudServerVersionTypeRepository.DEFAULT_TYPES_CACHE.get()!!.first { it.name == "unknown" }.uniqueId,
+            projectName,
+            null,
+            null,
+            mcVersion,
+            null,
+        )
+        if (serverVersionRepository.existsVersion(version.displayName)) {
+            actor.sendMessage(
+                "§cA server version with the project name $projectName and the mc version ${mcVersion.name}already exists!"
             )
-            if (serverVersionRepository.existsVersion(version.displayName)) {
-                actor.sendMessage(
-                    "§cA server version with the project name $projectName and the mc version ${mcVersion.name}already exists!"
-                )
-                return@launch
-            }
-            serverVersionRepository.createVersion(version)
-            actor.sendMessage("Created server version with name ${toConsoleValue(version.displayName)}")
-            actor.sendMessage("Use '/sv edit ${version.displayName} <key> <value>' to edit the server version")
+            return
         }
+        serverVersionRepository.createVersion(version)
+        actor.sendMessage("Created server version with name ${toConsoleValue(version.displayName)}")
+        actor.sendMessage("Use '/sv edit ${version.displayName} <key> <value>' to edit the server version")
     }
 
     @CommandSubPath("delete <version>")
     @CommandDescription("Delete a server version")
-    fun onDelete(
+    suspend fun onDelete(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion
     ) {
-        defaultScope.launch {
-            if (version.online) {
-                actor.sendMessage(
-                    "§cThe version ${
-                        toConsoleValue(
-                            version.displayName,
-                            false
-                        )
-                    } is online and can't be edited!"
-                )
-                return@launch
-            }
-            val servers = serverRepository.getConnectedServers()
-                .filter { it.configurationTemplate.serverVersionId == version.uniqueId }
-            if (servers.isNotEmpty()) {
-                actor.sendMessage("§cThere are still servers connected to this version:")
-                servers.forEach {
-                    actor.sendMessage("§8- %hc%${it.serviceId.toName()}")
-                }
-                return@launch
-            }
-            val templates = configurationTemplateRepository.getTemplates()
-                .filter { it.serverVersionId == version.uniqueId }
-            if (templates.isNotEmpty()) {
-                actor.sendMessage("§cThere are still configuration templates using this version:")
-                templates.forEach {
-                    actor.sendMessage("§8- %hc%${it.name}")
-                }
-                return@launch
-            }
-            serverVersionRepository.deleteVersion(version.uniqueId)
-            actor.sendMessage("Deleted server version with name ${toConsoleValue(version.displayName)}")
+        if (version.online) {
+            actor.sendMessage(
+                "§cThe version ${
+                    toConsoleValue(
+                        version.displayName,
+                        false
+                    )
+                } is online and can't be edited!"
+            )
+            return
         }
+        val servers = serverRepository.getConnectedServers()
+            .filter { it.configurationTemplate.serverVersionId == version.uniqueId }
+        if (servers.isNotEmpty()) {
+            actor.sendMessage("§cThere are still servers connected to this version:")
+            servers.forEach {
+                actor.sendMessage("§8- %hc%${it.serviceId.toName()}")
+            }
+            return
+        }
+        val templates = configurationTemplateRepository.getTemplates()
+            .filter { it.serverVersionId == version.uniqueId }
+        if (templates.isNotEmpty()) {
+            actor.sendMessage("§cThere are still configuration templates using this version:")
+            templates.forEach {
+                actor.sendMessage("§8- %hc%${it.name}")
+            }
+            return
+        }
+        serverVersionRepository.deleteVersion(version.uniqueId)
+        actor.sendMessage("Deleted server version with name ${toConsoleValue(version.displayName)}")
     }
 
     @CommandSubPath("list")
     @CommandDescription("List all versions")
-    fun onCreate(
+    suspend fun onCreate(
         actor: ConsoleActor
     ) {
-        defaultScope.launch {
-            val versions = serverVersionRepository.getVersions()
-            if (versions.isEmpty()) {
-                actor.sendMessage("§cThere are no server versions")
-                return@launch
-            }
-            val unknown = serverVersionTypeRepository.getOnlineTypes().first { it.isUnknown() }
-            val types = mutableMapOf<UUID, CloudServerVersionType>()
-            val map = mutableMapOf<UUID, MutableList<CloudServerVersion>>()
-            versions.forEach {
-                val type =
-                    if (it.typeId != null) serverVersionTypeRepository.getType(it.typeId!!) ?: unknown else unknown
-                val list = map.getOrDefault(type.uniqueId, mutableListOf())
-                list.add(it)
-                map[type.uniqueId] = list
-                types[type.uniqueId] = type
-            }
-            actor.sendHeader("Server-Versions")
-            actor.sendMessage("")
-            map.forEach {
-                val type = types[it.key]!!
-                val vs = it.value.sortedBy { it }
-                actor.sendMessage("§8- %hc%§n${type.name} §8§n(%tc%§n${vs.size}§8§n):")
-                var count = 0
-                var line = StringBuilder()
-                vs.forEach { version ->
-                    if (count == 5) {
-                        actor.sendMessage(line.toString())
-                        line = StringBuilder()
-                        count = 0
-                    }
-                    count++
-                    if (line.isEmpty()) {
-                        line.append("\t   §8➥ ")
-                    } else {
-                        line.append("§8, ")
-                    }
-                    val displayName = "%tc%${version.projectName}§8_%hc%${version.version.name}"
-                    line.append(
-                        "${displayName}${if (version.version.latest) " §8(%tc%${version.version.dynamicVersion().name}§8)" else ""}"
-                    )
-                }
-                if (line.isNotEmpty()) {
-                    actor.sendMessage(line.toString())
-                }
-                actor.sendMessage("")
-            }
-            actor.sendHeader("Server-Versions")
+        val versions = serverVersionRepository.getVersions()
+        if (versions.isEmpty()) {
+            actor.sendMessage("§cThere are no server versions")
+            return
         }
+        val unknown = serverVersionTypeRepository.getOnlineTypes().first { it.isUnknown() }
+        val types = mutableMapOf<UUID, CloudServerVersionType>()
+        val map = mutableMapOf<UUID, MutableList<CloudServerVersion>>()
+        versions.forEach {
+            val type =
+                if (it.typeId != null) serverVersionTypeRepository.getType(it.typeId!!) ?: unknown else unknown
+            val list = map.getOrDefault(type.uniqueId, mutableListOf())
+            list.add(it)
+            map[type.uniqueId] = list
+            types[type.uniqueId] = type
+        }
+        actor.sendHeader("Server-Versions")
+        actor.sendMessage("")
+        map.forEach {
+            val type = types[it.key]!!
+            val vs = it.value.sortedBy { it }
+            actor.sendMessage("§8- %hc%§n${type.name} §8§n(%tc%§n${vs.size}§8§n):")
+            var count = 0
+            var line = StringBuilder()
+            vs.forEach { version ->
+                if (count == 5) {
+                    actor.sendMessage(line.toString())
+                    line = StringBuilder()
+                    count = 0
+                }
+                count++
+                if (line.isEmpty()) {
+                    line.append("\t   §8➥ ")
+                } else {
+                    line.append("§8, ")
+                }
+                val displayName = "%tc%${version.projectName}§8_%hc%${version.version.name}"
+                line.append(
+                    "${displayName}${if (version.version.latest) " §8(%tc%${version.version.dynamicVersion().name}§8)" else ""}"
+                )
+            }
+            if (line.isNotEmpty()) {
+                actor.sendMessage(line.toString())
+            }
+            actor.sendMessage("")
+        }
+        actor.sendHeader("Server-Versions")
     }
 
     @CommandSubPath("info <version>")
     @CommandDescription("Get info about a version")
-    fun onInfo(
+    suspend fun onInfo(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion
     ) {
-        defaultScope.launch {
-            val type = if (version.typeId != null) serverVersionTypeRepository.getType(version.typeId!!) else null
-            actor.sendHeader("Server-Version info")
-            actor.sendMessage("")
-            actor.sendMessage("§8- %tc%Name§8: %hc%${version.displayName}")
-            actor.sendMessage("§8- %tc%Project§8: %hc%${version.projectName}")
-            actor.sendMessage("§8- %tc%Type§8: %hc%${type?.name ?: "unknown"}")
-            actor.sendMessage("§8- %tc%Lib-Pattern§8: %hc%${version.libPattern ?: "not set"}")
-            actor.sendMessage("§8- %tc%Online§8: %hc%${version.online.toSymbol()}")
-            actor.sendMessage("§8- %tc%Used§8: %hc%${version.used.toSymbol()}")
-            actor.sendMessage("§8- %tc%Version§8: %hc%${version.version.name}")
-            actor.sendMessage(
-                "§8- %tc%Version-Id§8: %hc%${
-                    if (version.version.latest) {
-                        "latest (${version.version.dynamicVersion().name})"
-                    } else {
-                        version.version.name
-                    }
-                }"
-            )
-            actor.sendMessage("§8- %tc%Patch-Version§8: ${version.patch.toSymbol()}")
-            actor.sendMessage("§8- %tc%Version-Handler§8: %hc%${type?.versionHandlerName ?: "unknown"}")
-            actor.sendMessage("§8- %tc%Download-Url§8: %hc%${version.customDownloadUrl ?: "not set"}")
-            actor.sendMessage("§8- %tc%Build§8: %hc%${version.buildId ?: "not set"}")
-            val javaVersion =
-                if (version.javaVersionId != null) javaVersionRepository.getVersion(version.javaVersionId!!) else null
-            actor.sendMessage("§8- %tc%Java version§8: %hc%${javaVersion?.name ?: "not set"}")
-            actor.sendMessage("§8- %tc%Default-Files§8:${if (version.defaultFiles.isEmpty()) " %hc%not set" else ""}")
-            version.defaultFiles.forEach {
-                actor.sendMessage("§8  - %hc%${it.key} §8➔ %tc%${it.value}")
-            }
-            actor.sendMessage("§8- %tc%JVM arguments§8:${if (version.jvmArguments.isEmpty()) " %hc%not set" else ""}")
-            version.jvmArguments.forEach {
-                actor.sendMessage("§8  - %hc%$it")
-            }
-            actor.sendMessage(
-                "§8- %tc%Program parameters§8:${if (version.programParameters.isEmpty()) " %hc%not set" else ""}"
-            )
-            version.programParameters.forEach {
-                actor.sendMessage("§8  - %hc%$it")
-            }
-            actor.sendMessage("§8- %tc%File edits§8:${if (version.fileEdits.isEmpty()) " %hc%not set" else ""}")
-            version.fileEdits.keys.forEach {
-                actor.sendMessage("\t§8- %hc%$it")
-                version.fileEdits[it]?.forEach { edit ->
-                    actor.sendMessage("\t   §8➥ %tc%${edit.key} §8➜ %tc%${edit.value}")
+        val type = if (version.typeId != null) serverVersionTypeRepository.getType(version.typeId!!) else null
+        actor.sendHeader("Server-Version info")
+        actor.sendMessage("")
+        actor.sendMessage("§8- %tc%Name§8: %hc%${version.displayName}")
+        actor.sendMessage("§8- %tc%Project§8: %hc%${version.projectName}")
+        actor.sendMessage("§8- %tc%Type§8: %hc%${type?.name ?: "unknown"}")
+        actor.sendMessage("§8- %tc%Lib-Pattern§8: %hc%${version.libPattern ?: "not set"}")
+        actor.sendMessage("§8- %tc%Online§8: %hc%${version.online.toSymbol()}")
+        actor.sendMessage("§8- %tc%Used§8: %hc%${version.used.toSymbol()}")
+        actor.sendMessage("§8- %tc%Version§8: %hc%${version.version.name}")
+        actor.sendMessage(
+            "§8- %tc%Version-Id§8: %hc%${
+                if (version.version.latest) {
+                    "latest (${version.version.dynamicVersion().name})"
+                } else {
+                    version.version.name
                 }
-            }
-            actor.sendMessage("")
-            actor.sendHeader("Server-Version info")
+            }"
+        )
+        actor.sendMessage("§8- %tc%Patch-Version§8: ${version.patch.toSymbol()}")
+        actor.sendMessage("§8- %tc%Version-Handler§8: %hc%${type?.versionHandlerName ?: "unknown"}")
+        actor.sendMessage("§8- %tc%Download-Url§8: %hc%${version.customDownloadUrl ?: "not set"}")
+        actor.sendMessage("§8- %tc%Build§8: %hc%${version.buildId ?: "not set"}")
+        val javaVersion =
+            if (version.javaVersionId != null) javaVersionRepository.getVersion(version.javaVersionId!!) else null
+        actor.sendMessage("§8- %tc%Java version§8: %hc%${javaVersion?.name ?: "not set"}")
+        actor.sendMessage("§8- %tc%Default-Files§8:${if (version.defaultFiles.isEmpty()) " %hc%not set" else ""}")
+        version.defaultFiles.forEach {
+            actor.sendMessage("§8  - %hc%${it.key} §8➔ %tc%${it.value}")
         }
+        actor.sendMessage("§8- %tc%JVM arguments§8:${if (version.jvmArguments.isEmpty()) " %hc%not set" else ""}")
+        version.jvmArguments.forEach {
+            actor.sendMessage("§8  - %hc%$it")
+        }
+        actor.sendMessage(
+            "§8- %tc%Program parameters§8:${if (version.programParameters.isEmpty()) " %hc%not set" else ""}"
+        )
+        version.programParameters.forEach {
+            actor.sendMessage("§8  - %hc%$it")
+        }
+        actor.sendMessage("§8- %tc%File edits§8:${if (version.fileEdits.isEmpty()) " %hc%not set" else ""}")
+        version.fileEdits.keys.forEach {
+            actor.sendMessage("\t§8- %hc%$it")
+            version.fileEdits[it]?.forEach { edit ->
+                actor.sendMessage("\t   §8➥ %tc%${edit.key} §8➜ %tc%${edit.value}")
+            }
+        }
+        actor.sendMessage("")
+        actor.sendHeader("Server-Version info")
     }
 
     @CommandSubPath("patch <version>")
     @CommandDescription("Patch a server version")
-    fun onPatch(
+    suspend fun onPatch(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion
     ) {
-        defaultScope.launch {
-            val type = if (version.typeId != null) serverVersionTypeRepository.getType(version.typeId!!) else null
-            if (type == null) {
-                actor.sendMessage("§cThis version has no server version type!")
-                actor.sendMessage("§cYou can set one with '/sv edit ${version.displayName} type <type>'")
-                return@launch
-            }
-            val handler = IServerVersionHandler.getHandler(type)
-            if (!handler.isPatchVersion(version)) {
-                actor.sendMessage(
-                    "§cThis version is not patchable! Set the lib pattern with '/sv edit ${version.displayName} patchh true'"
-                )
-                return@launch
-            }
-            try {
-                handler.patch(version)
-            } catch (e: CloudVersionException) {
-                LOGGER.severe("Error while patching version ${version.displayName}", e)
-            }
+        val type = if (version.typeId != null) serverVersionTypeRepository.getType(version.typeId!!) else null
+        if (type == null) {
+            actor.sendMessage("§cThis version has no server version type!")
+            actor.sendMessage("§cYou can set one with '/sv edit ${version.displayName} type <type>'")
+            return
+        }
+        val handler = IServerVersionHandler.getHandler(type)
+        if (!handler.isPatchVersion(version)) {
+            actor.sendMessage(
+                "§cThis version is not patchable! Set the lib pattern with '/sv edit ${version.displayName} patchh true'"
+            )
+            return
+        }
+        try {
+            handler.patch(version)
+        } catch (e: CloudVersionException) {
+            LOGGER.severe("Error while patching version ${version.displayName}", e)
         }
     }
 
     @CommandSubPath("download <version>")
     @CommandDescription("Download the server version")
-    fun onDownload(
+    suspend fun onDownload(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion
     ) {
-        defaultScope.launch {
-            val type = if (version.typeId != null) serverVersionTypeRepository.getType(version.typeId!!) else null
-            if (type == null) {
-                actor.sendMessage("§cThis version has no server version type!")
-                actor.sendMessage("§cYou can set one with '/sv edit ${version.projectName} type <type>'")
-                return@launch
-            }
-            val handler = IServerVersionHandler.getHandler(type)
-            if (!handler.canDownload(version)) {
-                actor.sendMessage(
-                    "§c'${version.displayName}' can´t be downloaded! Check the version type and the download url!"
-                )
-                return@launch
-            }
-            try {
-                handler.download(version, true)
-            } catch (e: CloudVersionException) {
-                LOGGER.severe("Error while downloading version ${version.displayName}", e)
-            }
+        val type = if (version.typeId != null) serverVersionTypeRepository.getType(version.typeId!!) else null
+        if (type == null) {
+            actor.sendMessage("§cThis version has no server version type!")
+            actor.sendMessage("§cYou can set one with '/sv edit ${version.projectName} type <type>'")
+            return
+        }
+        val handler = IServerVersionHandler.getHandler(type)
+        if (!handler.canDownload(version)) {
+            actor.sendMessage(
+                "§c'${version.displayName}' can´t be downloaded! Check the version type and the download url!"
+            )
+            return
+        }
+        try {
+            handler.download(version, true)
+        } catch (e: CloudVersionException) {
+            LOGGER.severe("Error while downloading version ${version.displayName}", e)
         }
     }
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/CloudServerVersionTypeCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/CloudServerVersionTypeCommand.kt
@@ -13,7 +13,6 @@ import dev.redicloud.service.base.suggester.CloudConnectorFileNameSelector
 import dev.redicloud.service.base.suggester.CloudServerVersionTypeSuggester
 import dev.redicloud.service.base.suggester.ServerVersionHandlerSuggester
 import dev.redicloud.utils.*
-import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.net.URL
 import java.util.*
@@ -30,63 +29,57 @@ class CloudServerVersionTypeCommand(
 
     @CommandSubPath("duplicate <name> [new-name]")
     @CommandDescription("Duplicate a server version type")
-    fun duplicate(
+    suspend fun duplicate(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("new-name", false) newName: String?
     ) {
-        runBlocking {
-            val newType = type.copy(newName ?: "${type.name}-copy")
-            if (serverVersionTypeRepository.existsType(newType.name)) {
-                actor.sendMessage("§cA server version type with this name already exists!")
-                return@runBlocking
-            }
-            serverVersionTypeRepository.createType(newType)
-            actor.sendMessage(
-                "Successfully duplicated server version type ${toConsoleValue(
-                    type.name
-                )} to ${toConsoleValue(newType.name)}"
-            )
+        val newType = type.copy(newName ?: "${type.name}-copy")
+        if (serverVersionTypeRepository.existsType(newType.name)) {
+            actor.sendMessage("§cA server version type with this name already exists!")
+            return
         }
+        serverVersionTypeRepository.createType(newType)
+        actor.sendMessage(
+            "Successfully duplicated server version type ${toConsoleValue(
+                type.name
+            )} to ${toConsoleValue(newType.name)}"
+        )
     }
 
     @CommandSubPath("list")
     @CommandDescription("List all server version types")
-    fun list(
+    suspend fun list(
         actor: ConsoleActor
     ) {
-        runBlocking {
-            val types = serverVersionTypeRepository.getTypes()
-            if (types.isEmpty()) {
-                actor.sendMessage("No server version types found!")
-                return@runBlocking
-            }
-            actor.sendMessage("Server version types§8:")
-            types.forEach {
-                actor.sendMessage(
-                    "§8- %hc%${it.name}"
-                )
-            }
+        val types = serverVersionTypeRepository.getTypes()
+        if (types.isEmpty()) {
+            actor.sendMessage("No server version types found!")
+            return
+        }
+        actor.sendMessage("Server version types§8:")
+        types.forEach {
+            actor.sendMessage(
+                "§8- %hc%${it.name}"
+            )
         }
     }
 
     @CommandSubPath("handlers")
     @CommandDescription("List all server version handlers")
-    fun handlers(
+    suspend fun handlers(
         actor: ConsoleActor
     ) {
-        runBlocking {
-            val handlers = IServerVersionHandler.CACHE_HANDLERS
-            if (handlers.isEmpty()) {
-                actor.sendMessage("No server version handlers found!")
-                return@runBlocking
-            }
-            actor.sendMessage("Server version handlers§8:")
-            handlers.forEach {
-                actor.sendMessage(
-                    "§8- %hc%${it.name}"
-                )
-            }
+        val handlers = IServerVersionHandler.CACHE_HANDLERS
+        if (handlers.isEmpty()) {
+            actor.sendMessage("No server version handlers found!")
+            return
+        }
+        actor.sendMessage("Server version handlers§8:")
+        handlers.forEach {
+            actor.sendMessage(
+                "§8- %hc%${it.name}"
+            )
         }
     }
 
@@ -150,378 +143,344 @@ class CloudServerVersionTypeCommand(
 
     @CommandSubPath("edit <type> files add <url> [path]")
     @CommandDescription("Add a file to the server version type that will be downloaded")
-    fun onEditFilesAdd(
+    suspend fun onEditFilesAdd(
         actor: ConsoleActor,
         @CommandParameter("type", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("url") url: String,
         @CommandParameter("path", false) path: String?
     ) {
-        runBlocking {
-            if (!isValidUrl(url)) {
-                actor.sendMessage("§cThe url '$url' is not valid!")
-                return@runBlocking
-            }
-            val file = path ?: URL(url).fileName
-            if (type.defaultFiles.any { it.value.lowercase() == file.lowercase() }) {
-                actor.sendMessage(
-                    "§cThe file with the url ${
-                        toConsoleValue(
-                            url,
-                            false
-                        )
-                    } was already added to the version ${toConsoleValue(type.name, false)}!"
-                )
-                return@runBlocking
-            }
-            type.defaultFiles[url] = file
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Added file with url ${toConsoleValue(url)} to ${toConsoleValue(type.name)}")
+        if (!isValidUrl(url)) {
+            actor.sendMessage("§cThe url '$url' is not valid!")
+            return
         }
+        val file = path ?: URL(url).fileName
+        if (type.defaultFiles.any { it.value.lowercase() == file.lowercase() }) {
+            actor.sendMessage(
+                "§cThe file with the url ${
+                    toConsoleValue(
+                        url,
+                        false
+                    )
+                } was already added to the version ${toConsoleValue(type.name, false)}!"
+            )
+            return
+        }
+        type.defaultFiles[url] = file
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Added file with url ${toConsoleValue(url)} to ${toConsoleValue(type.name)}")
     }
 
     @CommandSubPath("edit <version> libPattern <pattern>")
     @CommandDescription(
         "Set the lib pattern for the files that should be stored after the patch. Set to 'null' to disable the patching"
     )
-    fun onEditLibPattern(
+    suspend fun onEditLibPattern(
         actor: ConsoleActor,
         @CommandParameter("version", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("pattern", true) pattern: String
     ) {
-        runBlocking {
-            type.libPattern = if (pattern != "null") pattern else null
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage(
-                "Updated lib pattern of ${toConsoleValue(type.name)} to ${toConsoleValue(type.libPattern!!)}"
-            )
-        }
+        type.libPattern = if (pattern != "null") pattern else null
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage(
+            "Updated lib pattern of ${toConsoleValue(type.name)} to ${toConsoleValue(type.libPattern!!)}"
+        )
     }
 
     @CommandSubPath("edit <type> files remove <url>")
     @CommandDescription("Remove a file from the server version type that will be downloaded")
-    fun onEditFilesRemove(
+    suspend fun onEditFilesRemove(
         actor: ConsoleActor,
         @CommandParameter("type", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("url") url: String
     ) {
-        runBlocking {
-            if (type.defaultFiles.none { it.value.lowercase() == url.lowercase() }) {
-                actor.sendMessage(
-                    "§cThe file with the url '$url' is not added to the version ${toConsoleValue(type.name)}!"
-                )
-                return@runBlocking
-            }
-            type.defaultFiles.remove(url)
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Removed file with url ${toConsoleValue(url)} from ${toConsoleValue(type.name)}")
+        if (type.defaultFiles.none { it.value.lowercase() == url.lowercase() }) {
+            actor.sendMessage(
+                "§cThe file with the url '$url' is not added to the version ${toConsoleValue(type.name)}!"
+            )
+            return
         }
+        type.defaultFiles.remove(url)
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Removed file with url ${toConsoleValue(url)} from ${toConsoleValue(type.name)}")
     }
 
     @CommandSubPath("create <name>")
     @CommandDescription("Create a new server version type")
-    fun create(
+    suspend fun create(
         actor: ConsoleActor,
         @CommandParameter("name") name: String
     ) {
-        runBlocking {
-            if (serverVersionTypeRepository.existsType(name)) {
-                actor.sendMessage("§cA server version type with this name already exists!")
-                return@runBlocking
-            }
-            val type = CloudServerVersionType(
-                UUID.randomUUID(),
-                name,
-                "urldownloader",
-                false,
-                false,
-                "redicloud-$name-%cloud_version%-%build%.jar",
-                null,
-                "plugins"
-            )
-            serverVersionTypeRepository.createType(type)
-            actor.sendMessage("Successfully created server version type ${toConsoleValue(type.name)}")
+        if (serverVersionTypeRepository.existsType(name)) {
+            actor.sendMessage("§cA server version type with this name already exists!")
+            return
         }
+        val type = CloudServerVersionType(
+            UUID.randomUUID(),
+            name,
+            "urldownloader",
+            false,
+            false,
+            "redicloud-$name-%cloud_version%-%build%.jar",
+            null,
+            "plugins"
+        )
+        serverVersionTypeRepository.createType(type)
+        actor.sendMessage("Successfully created server version type ${toConsoleValue(type.name)}")
     }
 
     @CommandSubPath("delete <name>")
     @CommandDescription("Delete a server version type")
-    fun delete(
+    suspend fun delete(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType
     ) {
-        runBlocking {
-            val versions = configurationTemplateRepository.getTemplates().mapNotNull {
-                if (it.serverVersionId == null) return@mapNotNull null
-                serverVersionRepository.getVersion(it.serverVersionId!!)
-            }.filter { it.typeId != null }
-            if (versions.any { it.typeId == type.uniqueId }) {
-                actor.sendMessage("§cYou can't delete a server version type which is used by a server version:")
-                actor.sendMessage(
-                    "§c${
-                        versions.filter { it.typeId == type.uniqueId }.joinToString(", ") { it.displayName }
-                    }"
-                )
-                return@runBlocking
-            }
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't delete the default server version type!")
-                return@runBlocking
-            }
-            serverVersionTypeRepository.deleteType(type)
-            actor.sendMessage("Successfully deleted server version type ${toConsoleValue(type.name)}")
+        val versions = configurationTemplateRepository.getTemplates().mapNotNull {
+            if (it.serverVersionId == null) return@mapNotNull null
+            serverVersionRepository.getVersion(it.serverVersionId!!)
+        }.filter { it.typeId != null }
+        if (versions.any { it.typeId == type.uniqueId }) {
+            actor.sendMessage("§cYou can't delete a server version type which is used by a server version:")
+            actor.sendMessage(
+                "§c${
+                    versions.filter { it.typeId == type.uniqueId }.joinToString(", ") { it.displayName }
+                }"
+            )
+            return
         }
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't delete the default server version type!")
+            return
+        }
+        serverVersionTypeRepository.deleteType(type)
+        actor.sendMessage("Successfully deleted server version type ${toConsoleValue(type.name)}")
     }
 
     @CommandSubPath("edit <name> name <new-name>")
     @CommandDescription("Edit the name of a server version type")
-    fun editName(
+    suspend fun editName(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("new-name") newName: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.name = newName
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully edited name of server version type to ${toConsoleValue(type.name)}")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.name = newName
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully edited name of server version type to ${toConsoleValue(type.name)}")
     }
 
     @CommandSubPath("edit <name> handler <handler>")
     @CommandDescription("Edit the handler of a server version type")
-    fun editHandler(
+    suspend fun editHandler(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("handler", true, ServerVersionHandlerSuggester::class) newHandler: IServerVersionHandler
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.versionHandlerName = newHandler.name
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage(
-                "Successfully edited handler of server version type to ${toConsoleValue(type.versionHandlerName)}"
-            )
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.versionHandlerName = newHandler.name
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage(
+            "Successfully edited handler of server version type to ${toConsoleValue(type.versionHandlerName)}"
+        )
     }
 
     @CommandSubPath("edit <name> proxy <state>")
     @CommandDescription("Edit the proxy of a server version type")
-    fun editProxy(
+    suspend fun editProxy(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("state") proxy: Boolean
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.proxy = proxy
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully edited proxy of server version type to ${toConsoleValue(type.proxy)}")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.proxy = proxy
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully edited proxy of server version type to ${toConsoleValue(type.proxy)}")
     }
 
     @CommandSubPath("edit <name> connector file <file>")
     @CommandDescription("Edit the file name of the connector of a server version type")
-    fun editConnector(
+    suspend fun editConnector(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("file", true, CloudConnectorFileNameSelector::class) connector: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            val oldName = type.connectorPluginName
-            val file = File(CONNECTORS_FOLDER.getFile(), oldName)
-            if (file.exists()) {
-                file.renameTo(File(CONNECTORS_FOLDER.getFile(), connector))
-            }
-            type.connectorPluginName = connector
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage(
-                "Successfully edited connector of server version type to ${toConsoleValue(type.connectorPluginName)}"
-            )
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        val oldName = type.connectorPluginName
+        val file = File(CONNECTORS_FOLDER.getFile(), oldName)
+        if (file.exists()) {
+            file.renameTo(File(CONNECTORS_FOLDER.getFile(), connector))
+        }
+        type.connectorPluginName = connector
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage(
+            "Successfully edited connector of server version type to ${toConsoleValue(type.connectorPluginName)}"
+        )
     }
 
     @CommandSubPath("edit <name> connector url <url>")
     @CommandDescription("Edit the connector download url of a server version type")
-    fun editConnectorUrl(
+    suspend fun editConnectorUrl(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("url", true) url: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            if (!isValidUrl(url)) {
-                actor.sendMessage("§cThe url is not valid!")
-                return@runBlocking
-            }
-            type.connectorDownloadUrl = url
-            serverVersionTypeRepository.downloadConnector(type, true)
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage(
-                "Successfully edited connector download url of server version type to ${
-                    toConsoleValue(
-                        type.connectorDownloadUrl!!
-                    )
-                }"
-            )
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        if (!isValidUrl(url)) {
+            actor.sendMessage("§cThe url is not valid!")
+            return
+        }
+        type.connectorDownloadUrl = url
+        serverVersionTypeRepository.downloadConnector(type, true)
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage(
+            "Successfully edited connector download url of server version type to ${
+                toConsoleValue(
+                    type.connectorDownloadUrl!!
+                )
+            }"
+        )
     }
 
     @CommandSubPath("edit <name> connector folder <folder>")
     @CommandDescription("Edit the connector folder of a server version type. E.g. 'plugins' or 'extensions'")
-    fun editConnectorFolder(
+    suspend fun editConnectorFolder(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("folder", true) folder: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.connectorFolder = folder
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage(
-                "Successfully edited connector folder of server version type to ${toConsoleValue(type.connectorFolder)}"
-            )
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.connectorFolder = folder
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage(
+            "Successfully edited connector folder of server version type to ${toConsoleValue(type.connectorFolder)}"
+        )
     }
 
     @CommandSubPath("edit <name> jvmargument add <argument>")
     @CommandAlias(["edit <name> jvmarg add <argument>"])
     @CommandDescription("Add a jvm argument to a server version type")
-    fun addJvmArgument(
+    suspend fun addJvmArgument(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("argument") argument: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.jvmArguments.add(argument)
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully added jvm argument to server version type!")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.jvmArguments.add(argument)
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully added jvm argument to server version type!")
     }
 
     @CommandSubPath("edit <name> jvmargument remove <argument>")
     @CommandAlias(["edit <name> jvmarg remove <argument>"])
     @CommandDescription("Remove a jvm argument from a server version type")
-    fun removeJvmArgument(
+    suspend fun removeJvmArgument(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("parameter") argument: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.jvmArguments.remove(argument)
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully removed jvm parameter from server version type!")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.jvmArguments.remove(argument)
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully removed jvm parameter from server version type!")
     }
 
     @CommandSubPath("edit <name> programparameter add <parameter>")
     @CommandDescription("Add a program parameter to a server version type")
-    fun addProgramParameter(
+    suspend fun addProgramParameter(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("parameter") parameter: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.programParameters.add(parameter)
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully added program parameter to server version type!")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.programParameters.add(parameter)
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully added program parameter to server version type!")
     }
 
     @CommandSubPath("edit <name> programparameter remove <parameter>")
     @CommandDescription("Remove a program parameter to a server version type")
-    fun removeProgramParameter(
+    suspend fun removeProgramParameter(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("parameter") parameter: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            type.programParameters.remove(parameter)
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully removed the program parameter from server version type!")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        type.programParameters.remove(parameter)
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully removed the program parameter from server version type!")
     }
 
     @CommandSubPath("edit <name> fileedits add <file> <key> <value>")
     @CommandAlias(["edit <name> fe add <file> <key> <value>"])
     @CommandDescription("Add a file edit that should be applied before the server is starts")
-    fun addFileEdit(
+    suspend fun addFileEdit(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("file") file: String,
         @CommandParameter("key") key: String,
         @CommandParameter("value") value: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            val subMap = type.fileEdits.getOrDefault(file, mutableMapOf())
-            subMap[key] = value
-            if (subMap.isEmpty()) {
-                type.fileEdits.remove(file)
-            } else {
-                type.fileEdits[file] = subMap
-            }
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully added file edit to server version type!")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        val subMap = type.fileEdits.getOrDefault(file, mutableMapOf())
+        subMap[key] = value
+        if (subMap.isEmpty()) {
+            type.fileEdits.remove(file)
+        } else {
+            type.fileEdits[file] = subMap
+        }
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully added file edit to server version type!")
     }
 
     @CommandSubPath("edit <name> fileedits remove <file> <key>")
     @CommandAlias(["edit <name> fe remove <file> <key>"])
     @CommandDescription("Remove a file edit that should be applied before the server is starts")
-    fun removeFileEdit(
+    suspend fun removeFileEdit(
         actor: ConsoleActor,
         @CommandParameter("name", true, CloudServerVersionTypeSuggester::class) type: CloudServerVersionType,
         @CommandParameter("file") file: String,
         @CommandParameter("key") key: String
     ) {
-        runBlocking {
-            if (type.defaultType) {
-                actor.sendMessage("§cYou can't edit the name of the default server version type!")
-                return@runBlocking
-            }
-            val subMap = type.fileEdits.getOrDefault(file, mutableMapOf())
-            subMap.remove(key)
-            type.fileEdits[file] = subMap
-            serverVersionTypeRepository.updateType(type)
-            actor.sendMessage("Successfully removed file edit from server version type!")
+        if (type.defaultType) {
+            actor.sendMessage("§cYou can't edit the name of the default server version type!")
+            return
         }
+        val subMap = type.fileEdits.getOrDefault(file, mutableMapOf())
+        subMap.remove(key)
+        type.fileEdits[file] = subMap
+        serverVersionTypeRepository.updateType(type)
+        actor.sendMessage("Successfully removed file edit from server version type!")
     }
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ClusterCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ClusterCommand.kt
@@ -14,7 +14,6 @@ import dev.redicloud.service.node.repository.node.suspendNode
 import dev.redicloud.utils.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 @Command("cluster")
 @CommandDescription("All commands for the cluster")
@@ -30,47 +29,45 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
     @CommandSubPath("nodes")
     @CommandAlias(["list", "info"])
     @CommandDescription("List all nodes")
-    fun list(actor: ConsoleActor) {
-        runBlocking {
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                val nodes = nodeService.nodeRepository.getRegisteredNodes()
-                actor.sendHeader("Nodes")
-                nodes.forEach { node ->
-                    actor.sendMessage("")
-                    actor.sendMessage(
-                        "§8> §a${if (node.master) node.identifyName() + " §8(§6master§8)" else node.identifyName()}"
-                    )
-                    actor.sendMessage(
-                        "   - Status§8: %hc%${
-                            if (node.suspended) {
-                                "§4● §8(§fsuspended§8)"
-                            } else if (node.connected) {
-                                "§2● §8(§fconnected§8)"
-                            } else {
-                                "§c● §8(§fdisconnected§8)"
-                            }
-                        }"
-                    )
-                    actor.sendMessage("   - Memory§8: %hc%${node.currentMemoryUsage} §8/ %hc%${node.maxMemory}")
-                    actor.sendMessage("   - IP§8: %hc%${node.currentOrLastSession()?.ipAddress ?: "Unknown"}")
-                    if (node.connected) {
-                        sendPingMessage(node, actor, "   - Ping§8: ")
-                        val server = node.hostedServers.mapNotNull {
-                            nodeService.serverRepository.getServer<CloudServer>(
-                                it
-                            )?.name
-                        }
-                        actor.sendMessage(
-                            "   - Server§8: %hc%${if (server.isEmpty()) "None" else server.joinToString(", ")}"
-                        )
-                    }
-                }
+    suspend fun list(actor: ConsoleActor) {
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            val nodes = nodeService.nodeRepository.getRegisteredNodes()
+            actor.sendHeader("Nodes")
+            nodes.forEach { node ->
                 actor.sendMessage("")
-                actor.sendHeader("Nodes")
-            } catch (e: Exception) {
-                e.printStackTrace()
+                actor.sendMessage(
+                    "§8> §a${if (node.master) node.identifyName() + " §8(§6master§8)" else node.identifyName()}"
+                )
+                actor.sendMessage(
+                    "   - Status§8: %hc%${
+                        if (node.suspended) {
+                            "§4● §8(§fsuspended§8)"
+                        } else if (node.connected) {
+                            "§2● §8(§fconnected§8)"
+                        } else {
+                            "§c● §8(§fdisconnected§8)"
+                        }
+                    }"
+                )
+                actor.sendMessage("   - Memory§8: %hc%${node.currentMemoryUsage} §8/ %hc%${node.maxMemory}")
+                actor.sendMessage("   - IP§8: %hc%${node.currentOrLastSession()?.ipAddress ?: "Unknown"}")
+                if (node.connected) {
+                    sendPingMessage(node, actor, "   - Ping§8: ")
+                    val server = node.hostedServers.mapNotNull {
+                        nodeService.serverRepository.getServer<CloudServer>(
+                            it
+                        )?.name
+                    }
+                    actor.sendMessage(
+                        "   - Server§8: %hc%${if (server.isEmpty()) "None" else server.joinToString(", ")}"
+                    )
+                }
             }
+            actor.sendMessage("")
+            actor.sendHeader("Nodes")
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 
@@ -89,7 +86,7 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
 
     @CommandSubPath("templates push <node>")
     @CommandDescription("Push templates to the cluster")
-    fun pushTemplates(
+    suspend fun pushTemplates(
         actor: ConsoleActor,
         @CommandParameter("node", true, ConnectedCloudNodeSuggester::class) node: CloudNode
     ) {
@@ -97,40 +94,38 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
             actor.sendMessage("${node.identifyName()} is not connected to the cluster!")
             return
         }
-        runBlocking { nodeService.fileTemplateRepository.pushTemplates(node.serviceId) }
+        nodeService.fileTemplateRepository.pushTemplates(node.serviceId)
     }
 
     private val suspendConfirm = mutableMapOf<ServiceId, Long>()
 
     @CommandSubPath("suspend <node>")
     @CommandDescription("Suspend a node")
-    fun suspend(
+    suspend fun suspend(
         actor: ConsoleActor,
         @CommandParameter("node", true, ConnectedCloudNodeSuggester::class) node: CloudNode
     ) {
-        runBlocking {
-            if (suspendConfirm.contains(node.serviceId) && System.currentTimeMillis() - suspendConfirm[node.serviceId]!! < CONFIRM_TIMEOUT_MS) {
-                actor.sendMessage("Suspending node ${node.identifyName()}...")
-                nodeService.nodeRepository.suspendNode(nodeService, node.serviceId)
-                return@runBlocking
-            }
-            actor.sendHeader("Suspend")
-            actor.sendMessage("")
-            actor.sendMessage("Node§8: %hc%${node.identifyName()}")
-            actor.sendMessage(
-                "Servers§8: %hc%${node.hostedServers.mapNotNull { nodeService.serverRepository.getServer<CloudServer>(
-                    it
-                )?.name
-                }.joinToString(", ")}"
-            )
-            sendPingMessage(node, actor, "Ping§8: %hc%")
-            actor.sendMessage("")
-            actor.sendMessage("§cThis will suspend the node and all hosted servers will be stopped!")
-            actor.sendMessage("§cEnter the command again to confirm within 15 seconds")
-            actor.sendMessage("")
-            actor.sendHeader("Suspend")
-            suspendConfirm[node.serviceId] = System.currentTimeMillis()
+        if (suspendConfirm.contains(node.serviceId) && System.currentTimeMillis() - suspendConfirm[node.serviceId]!! < CONFIRM_TIMEOUT_MS) {
+            actor.sendMessage("Suspending node ${node.identifyName()}...")
+            nodeService.nodeRepository.suspendNode(nodeService, node.serviceId)
+            return
         }
+        actor.sendHeader("Suspend")
+        actor.sendMessage("")
+        actor.sendMessage("Node§8: %hc%${node.identifyName()}")
+        actor.sendMessage(
+            "Servers§8: %hc%${node.hostedServers.mapNotNull { nodeService.serverRepository.getServer<CloudServer>(
+                it
+            )?.name
+            }.joinToString(", ")}"
+        )
+        sendPingMessage(node, actor, "Ping§8: %hc%")
+        actor.sendMessage("")
+        actor.sendMessage("§cThis will suspend the node and all hosted servers will be stopped!")
+        actor.sendMessage("§cEnter the command again to confirm within 15 seconds")
+        actor.sendMessage("")
+        actor.sendHeader("Suspend")
+        suspendConfirm[node.serviceId] = System.currentTimeMillis()
     }
 
     @CommandSubPath("edit <node> maxmemory <value>")

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ClusterCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ClusterCommand.kt
@@ -10,6 +10,7 @@ import dev.redicloud.repository.server.CloudServer
 import dev.redicloud.service.base.repository.pingService
 import dev.redicloud.service.base.suggester.ConnectedCloudNodeSuggester
 import dev.redicloud.service.node.NodeService
+import dev.redicloud.service.node.repository.node.LOGGER
 import dev.redicloud.service.node.repository.node.suspendNode
 import dev.redicloud.utils.*
 import kotlinx.coroutines.delay
@@ -68,7 +69,7 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
             actor.sendMessage("")
             actor.sendHeader("Nodes")
         } catch (e: Exception) {
-            e.printStackTrace()
+            LOGGER.severe("Failed to list nodes", e)
         }
     }
 

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ClusterCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ClusterCommand.kt
@@ -14,6 +14,7 @@ import dev.redicloud.service.node.repository.node.suspendNode
 import dev.redicloud.utils.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 @Command("cluster")
 @CommandDescription("All commands for the cluster")
@@ -22,8 +23,8 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
     companion object {
         private const val CONFIRM_TIMEOUT_MS = 15000
         private const val ANIMATION_TICK_MS = 200L
-        private const val PING_DELAY_MS = 1500L
         private const val PING_PENDING = -2L
+        private val PING_DELAY_MS = 1500.milliseconds
     }
 
     @CommandSubPath("nodes")
@@ -130,15 +131,15 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
 
     @CommandSubPath("edit <node> maxmemory <value>")
     @CommandDescription("Edit the max memory of a node")
-    fun editMaxMemory(
+    suspend fun editMaxMemory(
         actor: ConsoleActor,
         @CommandParameter("node", true, ConnectedCloudNodeSuggester::class) node: CloudNode,
         @CommandParameter("memory", true, MemorySuggester::class) memory: Long
-    ) = defaultScope.launch {
+    ) {
         if (node.currentMemoryUsage > memory) {
             actor.sendMessage("§cThe memory usage of ${node.identifyName()} is higher than the new max memory!")
             actor.sendMessage("§cPlease stop some servers hosted on the node before changing the max memory!")
-            return@launch
+            return
         }
         node.maxMemory = memory
         nodeService.nodeRepository.updateNode(node)
@@ -149,24 +150,24 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
 
     @CommandSubPath("delete <node>")
     @CommandDescription("Delete a node")
-    fun delete(
+    suspend fun delete(
         actor: ConsoleActor,
         @CommandParameter("node", true, ConnectedCloudNodeSuggester::class) node: CloudNode
-    ) = defaultScope.launch {
+    ) {
         if (node.connected) {
             actor.sendMessage("§cThe node ${node.identifyName()} is still connected to the cluster!")
             actor.sendMessage("§cPlease disconnect the node before deleting it!")
-            return@launch
+            return
         }
         if (node.hostedServers.isNotEmpty()) {
             actor.sendMessage("§cThe node ${node.identifyName()} has still hosted servers on it!")
             actor.sendMessage("§cPlease stop/delete all servers hosted on the node before deleting it!")
-            return@launch
+            return
         }
         if (deleteConfirm.contains(node.serviceId) && System.currentTimeMillis() - deleteConfirm[node.serviceId]!! < CONFIRM_TIMEOUT_MS) {
             actor.sendMessage("Deleting node ${node.identifyName()}...")
             nodeService.nodeRepository.deleteNode(node.serviceId)
-            return@launch
+            return
         }
         actor.sendMessage("§cThis will delete the node! The cloud files on the remote server will not be deleted!")
         actor.sendMessage("§cEnter the command again to confirm within 15 seconds")
@@ -195,7 +196,7 @@ class ClusterCommand(private val nodeService: NodeService) : ICommand {
         }
         actor.console.startAnimation(pingAnimation)
         if (local) return
-        defaultScope.launch {
+        nodeService.scope.launch {
             delay(PING_DELAY_MS)
             ping = nodeService.nodeRepository.pingService(node.serviceId)
             block(ping)

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ConfigurationTemplateCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ConfigurationTemplateCommand.kt
@@ -19,7 +19,6 @@ import dev.redicloud.service.base.suggester.RegisteredCloudNodeSuggester
 import dev.redicloud.utils.fileName
 import dev.redicloud.utils.isValidUrl
 import dev.redicloud.utils.toSymbol
-import kotlinx.coroutines.runBlocking
 import java.net.URL
 import java.util.*
 import kotlin.time.Duration.Companion.milliseconds
@@ -51,15 +50,15 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("duplicate <name> [new-name]")
     @CommandDescription("Duplicate a configuration template")
-    fun duplicate(
+    suspend fun duplicate(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("new-name", false) newName: String?
-    ) = runBlocking {
+    ) {
         val newTemplate = template.copy(newName ?: "${template.name}-copy")
         if (configurationTemplateRepository.existsTemplate(newTemplate.name)) {
             actor.sendMessage("§cA configuration template with this name already exists!")
-            return@runBlocking
+            return
         }
         configurationTemplateRepository.createTemplate(newTemplate)
         actor.sendMessage(
@@ -71,13 +70,13 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("create <name>")
     @CommandDescription("Create a new configuration template")
-    fun create(
+    suspend fun create(
         actor: ConsoleActor,
         @CommandParameter("name") name: String
-    ) = runBlocking {
+    ) {
         if (configurationTemplateRepository.existsTemplate(name)) {
             actor.sendMessage("§cA configuration template with this name already exists!")
-            return@runBlocking
+            return
         }
         configurationTemplateRepository.createTemplate(
             ConfigurationTemplate(
@@ -104,14 +103,14 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("delete <name>")
     @CommandDescription("Delete a configuration template")
-    fun delete(
+    suspend fun delete(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate
-    ) = runBlocking {
+    ) {
         if (serverRepository.getRegisteredServers().any { it.configurationTemplate.uniqueId == template.uniqueId }) {
             actor.sendMessage("§cThere are still servers registered with this configuration template!")
             actor.sendMessage("§cStop the servers or delete them if it is a static server!")
-            return@runBlocking
+            return
         }
         configurationTemplateRepository.deleteTemplate(template)
         actor.sendMessage("§aThe configuration template was deleted successfully!")
@@ -119,11 +118,11 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("list")
     @CommandDescription("List all configuration templates")
-    fun list(actor: ConsoleActor) = runBlocking {
+    suspend fun list(actor: ConsoleActor) {
         val templates = configurationTemplateRepository.getTemplates()
         if (templates.isEmpty()) {
             actor.sendMessage("§cThere are no configuration templates!")
-            return@runBlocking
+            return
         }
         actor.sendHeader("Configuration templates")
         actor.sendMessage("")
@@ -136,10 +135,10 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("info <name>")
     @CommandDescription("Get information about a configuration template")
-    fun info(
+    suspend fun info(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate
-    ) = runBlocking {
+    ) {
         actor.sendHeader("Configuration template")
         actor.sendMessage("")
         actor.sendMessage("§8- %tc%Name§8: %hc%${template.name}")
@@ -217,11 +216,11 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> stoptime <minutes>")
     @CommandDescription("Set the time after a server should be stopped if it is useless")
-    fun editStopTime(
+    suspend fun editStopTime(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("time") time: Long
-    ) = runBlocking {
+    ) {
         template.timeAfterStopUselessServer = time.minutes.inWholeMilliseconds
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -233,11 +232,11 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> maxplayers <count>")
     @CommandDescription("Set the max players of a configuration template")
-    fun editMaxPlayers(
+    suspend fun editMaxPlayers(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("count", true, IntegerSuggester::class, ["10", "100", "10"]) count: Int
-    ) = runBlocking {
+    ) {
         template.maxPlayers = count
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage("Successfully set the max players of the configuration template to ${toConsoleValue(count)}!")
@@ -245,13 +244,13 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> fileedits add <file> <key> <value>")
     @CommandDescription("Add a file edit to a configuration template")
-    fun editFileEditsAdd(
+    suspend fun editFileEditsAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("file") file: String,
         @CommandParameter("key") key: String,
         @CommandParameter("value") value: String
-    ) = runBlocking {
+    ) {
         val subMap = template.fileEdits.getOrDefault(file, mutableMapOf())
         subMap[key] = value
         template.fileEdits[file] = subMap
@@ -261,16 +260,16 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> fileedits remove <file> <key>")
     @CommandDescription("Remove a file edit from a configuration template")
-    fun editFileEditsRemove(
+    suspend fun editFileEditsRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("file") file: String,
         @CommandParameter("key") key: String
-    ) = runBlocking {
+    ) {
         val subMap = template.fileEdits.getOrDefault(file, mutableMapOf())
         if (subMap.remove(key) == null) {
             actor.sendMessage("§cThe file edit with the key ${toConsoleValue(key, false)} does not exist!")
-            return@runBlocking
+            return
         }
         if (subMap.isEmpty()) {
             template.fileEdits.remove(file)
@@ -283,15 +282,15 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> files add <url> [path]")
     @CommandDescription("Add a default file to a configuration template")
-    fun editFilesAdd(
+    suspend fun editFilesAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("url") url: String,
         @CommandParameter("path", true) path: String?
-    ) = runBlocking {
+    ) {
         if (!isValidUrl(url)) {
             actor.sendMessage("§cThe url '$url' is not valid!")
-            return@runBlocking
+            return
         }
         val file = path ?: URL(url).fileName
         if (template.defaultFiles.any { it.value.lowercase() == file.lowercase() }) {
@@ -301,7 +300,7 @@ class ConfigurationTemplateCommand(
                     false
                 )} was already added to the configuration template ${toConsoleValue(template.name, false)}!"
             )
-            return@runBlocking
+            return
         }
         template.defaultFiles[path ?: url] = url
         configurationTemplateRepository.updateTemplate(template)
@@ -312,18 +311,18 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> files remove <url>")
     @CommandDescription("Remove a default file from a configuration template")
-    fun editFilesRemove(
+    suspend fun editFilesRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("url") url: String
-    ) = runBlocking {
+    ) {
         if (template.defaultFiles.none { it.value.lowercase() == url.lowercase() }) {
             actor.sendMessage(
                 "§cThe file with the url ${toConsoleValue(
                     url
                 )} is not added to the configuration template ${toConsoleValue(template.name, false)}!"
             )
-            return@runBlocking
+            return
         }
         template.defaultFiles.remove(url)
         configurationTemplateRepository.updateTemplate(template)
@@ -336,14 +335,14 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> name <new-name>")
     @CommandDescription("Edit the name of a configuration template")
-    fun editName(
+    suspend fun editName(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("new-name") newName: String
-    ) = runBlocking {
+    ) {
         if (configurationTemplateRepository.existsTemplate(newName)) {
             actor.sendMessage("§cA configuration template with this name already exists!")
-            return@runBlocking
+            return
         }
         template.name = newName
         configurationTemplateRepository.updateTemplate(template)
@@ -352,11 +351,11 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> programparameter add <parameter>")
     @CommandDescription("Add a program parameter to a configuration template")
-    fun editProgramParameterAdd(
+    suspend fun editProgramParameterAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("parameter") parameter: String
-    ) = runBlocking {
+    ) {
         template.programParameters.add(parameter)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -368,11 +367,11 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> programparameter remove <parameter>")
     @CommandDescription("Remove a program parameter from a configuration template")
-    fun editProgramParameterRemove(
+    suspend fun editProgramParameterRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("parameter") parameter: String
-    ) = runBlocking {
+    ) {
         template.programParameters.remove(parameter)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -385,11 +384,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> jvmargument add <argument>")
     @CommandAlias(["edit <name> ja add <argument>"])
     @CommandDescription("Add a JVM argument to a configuration template")
-    fun editJvmArgumentAdd(
+    suspend fun editJvmArgumentAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("argument") argument: String
-    ) = runBlocking {
+    ) {
         template.jvmArguments.add(argument)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -402,11 +401,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> jvmargument remove <argument>")
     @CommandAlias(["edit <name> ja remove <argument>"])
     @CommandDescription("Remove a JVM argument from a configuration template")
-    fun editJvmArgumentRemove(
+    suspend fun editJvmArgumentRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("argument") argument: String
-    ) = runBlocking {
+    ) {
         template.jvmArguments.remove(argument)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -419,12 +418,12 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> environment add <key> <value>")
     @CommandAlias(["edit <name> env add <key> <value>"])
     @CommandDescription("Add an environment variable to a configuration template")
-    fun editEnvironmentAdd(
+    suspend fun editEnvironmentAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("key") key: String,
         @CommandParameter("value") value: String
-    ) = runBlocking {
+    ) {
         template.environmentVariables[key] = value
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -438,12 +437,12 @@ class ConfigurationTemplateCommand(
     @CommandAlias(["edit <name> env remove <key>"])
     @CommandDescription("Remove an environment variable from a configuration template")
     @Suppress("UnusedParameter")
-    fun editEnvironmentRemove(
+    suspend fun editEnvironmentRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("key") key: String,
         @CommandParameter("value") value: String
-    ) = runBlocking {
+    ) {
         template.environmentVariables.remove(key)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -456,11 +455,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> maxmemory <memory>")
     @CommandAlias(["edit <name> mm <memory>"])
     @CommandDescription("Edit the maximum memory of a configuration template")
-    fun editMaxMemory(
+    suspend fun editMaxMemory(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("memory", true, MemorySuggester::class) memory: Long
-    ) = runBlocking {
+    ) {
         template.maxMemory = memory
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -473,11 +472,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> filetemplates add <template>")
     @CommandAlias(["edit <name> ft add <template>"])
     @CommandDescription("Add a file template to a configuration template")
-    fun editFileTemplateAdd(
+    suspend fun editFileTemplateAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("template", true, FileTemplateSuggester::class) fileTemplate: FileTemplate
-    ) = runBlocking {
+    ) {
         template.fileTemplateIds.add(fileTemplate.uniqueId)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -490,11 +489,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> filetemplates remove <template>")
     @CommandAlias(["edit <name> ft remove <template>"])
     @CommandDescription("Remove a file template from a configuration template")
-    fun editFileTemplateRemove(
+    suspend fun editFileTemplateRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("template", true, FileTemplateSuggester::class) fileTemplate: FileTemplate
-    ) = runBlocking {
+    ) {
         template.fileTemplateIds.remove(fileTemplate.uniqueId)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -507,11 +506,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> nodes add <node>")
     @CommandAlias(["edit <name> node add <node>"])
     @CommandDescription("Add a node to a configuration template")
-    fun editNodeAdd(
+    suspend fun editNodeAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("node", true, RegisteredCloudNodeSuggester::class) node: CloudNode
-    ) = runBlocking {
+    ) {
         template.nodeIds.add(node.serviceId)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -524,11 +523,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> nodes remove <node>")
     @CommandAlias(["edit <name> node remove <node>"])
     @CommandDescription("Remove a node from a configuration template")
-    fun editNodeRemove(
+    suspend fun editNodeRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("node", true, RegisteredCloudNodeSuggester::class) node: CloudNode
-    ) = runBlocking {
+    ) {
         template.nodeIds.remove(node.serviceId)
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -549,23 +548,23 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> minServices <count>")
     @CommandDescription("Edit the minimum amount of started services of a configuration template")
-    fun editMinStartedServices(
+    suspend fun editMinStartedServices(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("count", true, IntegerSuggester::class) count: Int
-    ) = runBlocking {
+    ) {
         if (count != -1) {
             if (template.maxStartedServices in 1 until count) {
                 actor.sendMessage(
                     "The minimum amount of started services cannot be higher than the maximum amount of started services!"
                 )
-                return@runBlocking
+                return
             }
             if (template.maxStartedServicesPerNode in 1 until count) {
                 actor.sendMessage(
                     "The minimum amount of started services cannot be higher than the maximum amount of started services per node!"
                 )
-                return@runBlocking
+                return
             }
         }
         template.minStartedServices = count
@@ -579,23 +578,23 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> maxServices <count>")
     @CommandDescription("Edit the maximum amount of started services of a configuration template")
-    fun editMaxStartedServices(
+    suspend fun editMaxStartedServices(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("count", true, IntegerSuggester::class) count: Int
-    ) = runBlocking {
+    ) {
         if (count != -1) {
             if (count < template.minStartedServices && template.minStartedServices > 0) {
                 actor.sendMessage(
                     "The maximum amount of started services cannot be lower than the minimum amount of started services!"
                 )
-                return@runBlocking
+                return
             }
             if (count < template.minStartedServicesPerNode && template.minStartedServicesPerNode > 0) {
                 actor.sendMessage(
                     "The maximum amount of started services cannot be lower than the minimum amount of started services per node!"
                 )
-                return@runBlocking
+                return
             }
         }
         template.maxStartedServices = count
@@ -609,29 +608,29 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> minServicesPerNode <count>")
     @CommandDescription("Edit the minimum amount of started services per node of a configuration template")
-    fun editMinStartedServicesPerNode(
+    suspend fun editMinStartedServicesPerNode(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("count", true, IntegerSuggester::class) count: Int
-    ) = runBlocking {
+    ) {
         if (count != -1) {
             if (template.minStartedServices in 1 until count) {
                 actor.sendMessage(
                     "The minimum amount of started services per node cannot be higher than the maximum amount of started services!"
                 )
-                return@runBlocking
+                return
             }
             if (template.maxStartedServicesPerNode in 1 until count) {
                 actor.sendMessage(
                     "The minimum amount of started services per node cannot be higher than the maximum amount of started services per node!"
                 )
-                return@runBlocking
+                return
             }
             if (template.maxStartedServices in 1 until count) {
                 actor.sendMessage(
                     "The minimum amount of started services per node cannot be higher than the maximum amount of started services!"
                 )
-                return@runBlocking
+                return
             }
         }
         template.minStartedServicesPerNode = count
@@ -645,29 +644,29 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> maxServicesPerNode <count>")
     @CommandDescription("Edit the maximum amount of started services per node of a configuration template")
-    fun editMaxStartedServicesPerNode(
+    suspend fun editMaxStartedServicesPerNode(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("count", true, IntegerSuggester::class) count: Int
-    ) = runBlocking {
+    ) {
         if (count != -1) {
             if (count < template.minStartedServicesPerNode && template.minStartedServicesPerNode > 0) {
                 actor.sendMessage(
                     "The maximum amount of started services per node cannot be lower than the minimum amount of started services per node!"
                 )
-                return@runBlocking
+                return
             }
             if (template.maxStartedServices in 1 until count) {
                 actor.sendMessage(
                     "The maximum amount of started services per node cannot be higher than the maximum amount of started services!"
                 )
-                return@runBlocking
+                return
             }
             if (template.maxStartedServicesPerNode in 1 until count) {
                 actor.sendMessage(
                     "The maximum amount of started services per node cannot be higher than the maximum amount of started services per node!"
                 )
-                return@runBlocking
+                return
             }
         }
         template.maxStartedServicesPerNode = count
@@ -681,14 +680,14 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> percentToStartNew <percent>")
     @CommandDescription("Edit the percent of player online to start a new service of a configuration template")
-    fun editPercentToStartNew(
+    suspend fun editPercentToStartNew(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("percent", true) percent: Double
-    ) = runBlocking {
+    ) {
         if (percent < 0 || percent > 100) {
             actor.sendMessage("§cThe percent must be between 0 and 100!")
-            return@runBlocking
+            return
         }
         template.percentToStartNewService = percent
         configurationTemplateRepository.updateTemplate(template)
@@ -701,14 +700,14 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> splitter <value>")
     @CommandDescription("Edit the server splitter of a configuration template")
-    fun editSplitter(
+    suspend fun editSplitter(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("value", true) splitter: String
-    ) = runBlocking {
+    ) {
         if (splitter.length > 3) {
             actor.sendMessage("§cThe splitter cannot be longer than 3 characters!")
-            return@runBlocking
+            return
         }
         if (invalidChars.containsMatchIn(splitter)) {
             actor.sendMessage(
@@ -716,11 +715,11 @@ class ConfigurationTemplateCommand(
                     ""
                 ).joinToString(", ")}"
             )
-            return@runBlocking
+            return
         }
         if (invalidNames.contains(splitter.lowercase())) {
             actor.sendMessage("§cThe splitter cannot be any of the following names: ${invalidNames.joinToString(", ")}")
-            return@runBlocking
+            return
         }
         val servers = serverRepository.getRegisteredServers().filter { it.configurationTemplate.uniqueId == template.uniqueId }
         if (servers.isNotEmpty()) {
@@ -728,7 +727,7 @@ class ConfigurationTemplateCommand(
                 "§cThe splitter cannot be changed while there are still servers registered on this template!"
             )
             actor.sendMessage("§cRegistered servers: ${servers.joinToString(", ") { it.name }}")
-            return@runBlocking
+            return
         }
         template.serverSplitter = if (splitter == "''") "" else splitter
         configurationTemplateRepository.updateTemplate(template)
@@ -741,11 +740,11 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> fallback <value>")
     @CommandDescription("Edit if the fallback server should be enabled or not of a configuration template")
-    fun editFallback(
+    suspend fun editFallback(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("value", true, BooleanSuggester::class) fallback: Boolean
-    ) = runBlocking {
+    ) {
         template.fallbackServer = fallback
         configurationTemplateRepository.updateTemplate(template)
         if (fallback) {
@@ -761,14 +760,14 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> startPriority <priority>")
     @CommandDescription("Edit the start priority of a configuration template")
-    fun editStartPriority(
+    suspend fun editStartPriority(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("priority", true, IntegerSuggester::class, ["0", "100"]) priority: Int
-    ) = runBlocking {
+    ) {
         if (priority < 0 || priority > 100) {
             actor.sendMessage("§cThe priority must be between 0 and 100!")
-            return@runBlocking
+            return
         }
         template.startPriority = priority
         configurationTemplateRepository.updateTemplate(template)
@@ -779,11 +778,11 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> version <version>")
     @CommandDescription("Edit the server version of a configuration template")
-    fun editVersion(
+    suspend fun editVersion(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("version", true, CloudServerVersionSuggester::class) version: CloudServerVersion
-    ) = runBlocking {
+    ) {
         template.serverVersionId = version.uniqueId
         configurationTemplateRepository.updateTemplate(template)
         actor.sendMessage(
@@ -793,14 +792,14 @@ class ConfigurationTemplateCommand(
 
     @CommandSubPath("edit <name> startport <port>")
     @CommandDescription("Edit the start port!")
-    fun editStartPort(
+    suspend fun editStartPort(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("port", true) port: Int
-    ) = runBlocking {
+    ) {
         if (port < 100 || port > MAX_PORT) {
             actor.sendMessage("§cThe port must be between 100 and $MAX_PORT!")
-            return@runBlocking
+            return
         }
         template.startPort = port
         configurationTemplateRepository.updateTemplate(template)
@@ -810,11 +809,11 @@ class ConfigurationTemplateCommand(
     @CommandSubPath("edit <name> static <state>")
     @CommandAlias(["edit <name> static <state>"])
     @CommandDescription("Edit the static service state of a configuration template")
-    fun editStaticService(
+    suspend fun editStaticService(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("state", true, BooleanSuggester::class) staticService: Boolean
-    ) = runBlocking {
+    ) {
         val servers = serverRepository.getRegisteredServers().filter { it.configurationTemplate.uniqueId == template.uniqueId }
         if (servers.isNotEmpty()) {
             actor.sendMessage(
@@ -822,7 +821,7 @@ class ConfigurationTemplateCommand(
                     "registered! Delete all static servers or stop all dynamic servers first!"
             )
             actor.sendMessage("§cRegistered servers: ${servers.joinToString(", ") { it.name}}")
-            return@runBlocking
+            return
         }
         template.static = staticService
         configurationTemplateRepository.updateTemplate(template)
@@ -835,11 +834,11 @@ class ConfigurationTemplateCommand(
     @CommandDescription(
         "Edit the permission that is required to join a service of a configuration template! Use 'null' to remove the permission"
     )
-    fun editPermission(
+    suspend fun editPermission(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("permission", true) permission: String
-    ) = runBlocking {
+    ) {
         template.joinPermission = if (permission == "null") null else permission
         configurationTemplateRepository.updateTemplate(template)
         if (permission == "null") {

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ExitCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ExitCommand.kt
@@ -3,9 +3,9 @@ package dev.redicloud.service.node.commands
 import dev.redicloud.api.commands.*
 import dev.redicloud.console.commands.ConsoleActor
 import dev.redicloud.service.node.NodeService
-import dev.redicloud.utils.defaultScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 @Command("exit")
 @CommandAlias(["stop", "quit"])
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 class ExitCommand(private val nodeService: NodeService) : ICommand {
 
     companion object {
-        private const val EXIT_CONFIRM_TIMEOUT_MS = 10000L
+        private val EXIT_CONFIRM_TIMEOUT_MS = 10000.milliseconds
     }
 
     private var confirmed = System.getProperty("redicloud.exit.confirm", "false").toBoolean()
@@ -23,7 +23,7 @@ class ExitCommand(private val nodeService: NodeService) : ICommand {
         if (!confirmed) {
             actor.sendMessage("§cTo shutdown the node enter the command again within 10 seconds!")
             confirmed = true
-            defaultScope.launch {
+            nodeService.scope.launch {
                 delay(EXIT_CONFIRM_TIMEOUT_MS)
                 confirmed = false
             }
@@ -37,7 +37,7 @@ class ExitCommand(private val nodeService: NodeService) : ICommand {
         if (!confirmed) {
             actor.sendMessage("§cTo shutdown the node enter the command again within 10 seconds!")
             confirmed = true
-            defaultScope.launch {
+            nodeService.scope.launch {
                 delay(EXIT_CONFIRM_TIMEOUT_MS)
                 confirmed = false
             }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/FileTemplateCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/FileTemplateCommand.kt
@@ -8,8 +8,6 @@ import dev.redicloud.repository.template.file.AbstractFileTemplateRepository
 import dev.redicloud.repository.template.file.FileTemplate
 import dev.redicloud.service.base.suggester.ConnectedCloudNodeSuggester
 import dev.redicloud.service.base.suggester.FileTemplateSuggester
-import dev.redicloud.utils.defaultScope
-import kotlinx.coroutines.launch
 import java.util.*
 
 @Command("filetemplate")
@@ -21,11 +19,11 @@ class FileTemplateCommand(
 
     @CommandSubPath("duplicate <name> [new-name]")
     @CommandDescription("Duplicate a file template")
-    fun duplicate(
+    suspend fun duplicate(
         actor: ConsoleActor,
         @CommandParameter("name", true, FileTemplateSuggester::class) template: FileTemplate,
         @CommandParameter("new-name", false) newName: String?
-    ) = defaultScope.launch {
+    ) {
         val newTemplate = template.copy(newName ?: "${template.name}_copy")
         if (fileTemplateRepository.existsTemplate(newTemplate.name, newTemplate.prefix)) {
             actor.sendMessage(
@@ -33,7 +31,7 @@ class FileTemplateCommand(
                     newTemplate.name
                 )} and prefix ${toConsoleValue(newTemplate.prefix)} already exists!"
             )
-            return@launch
+            return
         }
         actor.sendMessage(
             "File template ${toConsoleValue(
@@ -100,18 +98,18 @@ class FileTemplateCommand(
 
     @CommandSubPath("create <name> <prefix>")
     @CommandDescription("Create a new file template")
-    fun create(
+    suspend fun create(
         actor: ConsoleActor,
         @CommandParameter("name") name: String,
         @CommandParameter("prefix") prefix: String
-    ) = defaultScope.launch {
+    ) {
         if (fileTemplateRepository.existsTemplate(name, prefix)) {
             actor.sendMessage(
                 "§cA file template with the name ${toConsoleValue(
                     name
                 )} and prefix ${toConsoleValue(prefix)} already exists!"
             )
-            return@launch
+            return
         }
         val template = FileTemplate(
             UUID.randomUUID(),
@@ -126,10 +124,10 @@ class FileTemplateCommand(
 
     @CommandSubPath("delete <name>")
     @CommandDescription("Delete a file template")
-    fun delete(
+    suspend fun delete(
         actor: ConsoleActor,
         @CommandParameter("name", true, FileTemplateSuggester::class) template: FileTemplate
-    ) = defaultScope.launch {
+    ) {
         actor.sendMessage("File template ${toConsoleValue(template.displayName)} will be deleted...")
         fileTemplateRepository.deleteTemplate(template.uniqueId)
         actor.sendMessage("File template ${toConsoleValue(template.displayName)} was deleted!")
@@ -207,18 +205,18 @@ class FileTemplateCommand(
 
     @CommandSubPath("edit <name> name <new-name>")
     @CommandDescription("Change the name of a file template")
-    fun editName(
+    suspend fun editName(
         actor: ConsoleActor,
         @CommandParameter("name", true, FileTemplateSuggester::class) template: FileTemplate,
         @CommandParameter("new-name") newName: String
-    ) = defaultScope.launch {
+    ) {
         if (fileTemplateRepository.existsTemplate(newName, template.prefix)) {
             actor.sendMessage(
                 "§cA file template with the name ${toConsoleValue(
                     newName
                 )} and prefix ${toConsoleValue(template.prefix)} already exists!"
             )
-            return@launch
+            return
         }
         actor.sendMessage(
             "File template ${toConsoleValue(template.displayName)} will be renamed to ${toConsoleValue(newName)}..."
@@ -232,18 +230,18 @@ class FileTemplateCommand(
 
     @CommandSubPath("edit <name> prefix <new-prefix>")
     @CommandDescription("Change the prefix of a file template")
-    fun editPrefix(
+    suspend fun editPrefix(
         actor: ConsoleActor,
         @CommandParameter("name", true, FileTemplateSuggester::class) template: FileTemplate,
         @CommandParameter("new-prefix") newPrefix: String
-    ) = defaultScope.launch {
+    ) {
         if (fileTemplateRepository.existsTemplate(template.name, newPrefix)) {
             actor.sendMessage(
                 "§cA file template with the name ${toConsoleValue(
                     template.name
                 )} and prefix ${toConsoleValue(newPrefix)} already exists!"
             )
-            return@launch
+            return
         }
         actor.sendMessage(
             "File template ${toConsoleValue(template.displayName)} will be renamed to ${toConsoleValue(newPrefix)}..."
@@ -257,13 +255,13 @@ class FileTemplateCommand(
 
     @CommandSubPath("publish <node>")
     @CommandDescription("Publish a file template to a node")
-    fun publish(
+    suspend fun publish(
         actor: ConsoleActor,
         @CommandParameter("node", true, ConnectedCloudNodeSuggester::class) node: CloudNode,
-    ) = defaultScope.launch {
+    ) {
         if (node.currentSession == null) {
             actor.sendMessage("§cThe node ${toConsoleValue(node.name)} is not connected!")
-            return@launch
+            return
         }
         fileTemplateRepository.pushTemplates(node.serviceId)
     }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/FileTemplateCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/FileTemplateCommand.kt
@@ -10,7 +10,6 @@ import dev.redicloud.service.base.suggester.ConnectedCloudNodeSuggester
 import dev.redicloud.service.base.suggester.FileTemplateSuggester
 import dev.redicloud.utils.defaultScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.*
 
 @Command("filetemplate")
@@ -54,9 +53,9 @@ class FileTemplateCommand(
 
     @CommandSubPath("list")
     @CommandDescription("List all file templates")
-    fun list(
+    suspend fun list(
         actor: ConsoleActor
-    ) = runBlocking {
+    ) {
         val v = fileTemplateRepository.getTemplates()
         val versions = mutableMapOf<String, MutableList<String>>()
         v.forEach {
@@ -66,7 +65,7 @@ class FileTemplateCommand(
         }
         if (versions.isEmpty()) {
             actor.sendMessage("§cNo file templates found")
-            return@runBlocking
+            return
         }
         actor.sendHeader("File templates")
         actor.sendMessage("")
@@ -82,10 +81,10 @@ class FileTemplateCommand(
 
     @CommandSubPath("info <name>")
     @CommandDescription("Get info about a file template")
-    fun info(
+    suspend fun info(
         actor: ConsoleActor,
         @CommandParameter("name", true, FileTemplateSuggester::class) template: FileTemplate
-    ) = runBlocking {
+    ) {
         val inherited = fileTemplateRepository.collectTemplates(template)
         actor.sendHeader("File template")
         actor.sendMessage("")
@@ -138,11 +137,11 @@ class FileTemplateCommand(
 
     @CommandSubPath("edit <name> inherit add <inherit>")
     @CommandDescription("Add a file template to the inheritance of a file template")
-    fun editInheritAdd(
+    suspend fun editInheritAdd(
         actor: ConsoleActor,
         @CommandParameter("name", true, FileTemplateSuggester::class) template: FileTemplate,
         @CommandParameter("inherit", true, FileTemplateSuggester::class) inherit: FileTemplate
-    ) = runBlocking {
+    ) {
         if (template.inherited.contains(inherit.uniqueId)) {
             actor.sendMessage(
                 "§cThe file template ${toConsoleValue(
@@ -150,7 +149,7 @@ class FileTemplateCommand(
                     false
                 )} already inherits from ${toConsoleValue(inherit.displayName, false)}!"
             )
-            return@runBlocking
+            return
         }
         val allTemplates = fileTemplateRepository.collectTemplates(template)
         if (allTemplates.contains(inherit)) {
@@ -160,7 +159,7 @@ class FileTemplateCommand(
                     false
                 )} already inherits from ${toConsoleValue(inherit.displayName, false)}!"
             )
-            return@runBlocking
+            return
         }
         actor.sendMessage(
             "File template ${toConsoleValue(
@@ -178,11 +177,11 @@ class FileTemplateCommand(
 
     @CommandSubPath("edit <name> inherit remove <inherit>")
     @CommandDescription("Remove a file template from the inheritance of a file template")
-    fun editInheritRemove(
+    suspend fun editInheritRemove(
         actor: ConsoleActor,
         @CommandParameter("name", true, FileTemplateSuggester::class) template: FileTemplate,
         @CommandParameter("inherit", true, FileTemplateSuggester::class) inherit: FileTemplate
-    ) = runBlocking {
+    ) {
         if (!template.inherited.contains(inherit.uniqueId)) {
             actor.sendMessage(
                 "§cThe file template ${toConsoleValue(
@@ -190,7 +189,7 @@ class FileTemplateCommand(
                     false
                 )} does not inherit from ${toConsoleValue(inherit.displayName, false)}!"
             )
-            return@runBlocking
+            return
         }
         actor.sendMessage(
             "File template ${toConsoleValue(

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/JavaVersionCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/JavaVersionCommand.kt
@@ -9,10 +9,8 @@ import dev.redicloud.repository.java.version.getVersionInfo
 import dev.redicloud.repository.server.version.CloudServerVersionRepository
 import dev.redicloud.service.base.suggester.JavaVersionSuggester
 import dev.redicloud.utils.OSType
-import dev.redicloud.utils.defaultScope
 import dev.redicloud.utils.getOperatingSystemType
 import dev.redicloud.utils.toSymbol
-import kotlinx.coroutines.launch
 import java.io.File
 import java.util.*
 
@@ -26,9 +24,9 @@ class JavaVersionCommand(
 
     @CommandSubPath("list")
     @CommandDescription("List all java versions")
-    fun list(
+    suspend fun list(
         actor: ConsoleActor
-    ) = defaultScope.launch {
+    ) {
         actor.sendHeader("Java-Versions")
         actor.sendMessage("")
         javaVersionRepository.getVersions().forEach {
@@ -42,13 +40,13 @@ class JavaVersionCommand(
 
     @CommandSubPath("auto-locate")
     @CommandDescription("Auto locate all java versions")
-    fun autoLocate(
+    suspend fun autoLocate(
         actor: ConsoleActor
-    ) = defaultScope.launch {
+    ) {
         val versions = javaVersionRepository.detectInstalledVersions()
         if (versions.isEmpty()) {
             actor.sendMessage("§cNo java versions found")
-            return@launch
+            return
         }
         val created = mutableListOf<CloudJavaVersion>()
         versions.forEach {
@@ -58,17 +56,17 @@ class JavaVersionCommand(
         }
         if (created.isEmpty()) {
             actor.sendMessage("No new java versions found")
-            return@launch
+            return
         }
         actor.sendMessage("Created new java versions§8: %hc%${created.joinToString("§8, %hc%") { it.name }}")
     }
 
     @CommandSubPath("delete <version>")
     @CommandDescription("Delete a java version")
-    fun delete(
+    suspend fun delete(
         actor: ConsoleActor,
         @CommandParameter("version", true, JavaVersionSuggester::class) version: CloudJavaVersion
-    ) = defaultScope.launch {
+    ) {
         val versions = serverVersionRepository.getVersions()
         if (versions.any { it.uniqueId == version.uniqueId }) {
             actor.sendMessage("§cThere are still server versions using this version:")
@@ -77,7 +75,7 @@ class JavaVersionCommand(
                     versions.filter { it.javaVersionId == version.uniqueId }.joinToString(", ") { it.displayName }
                 }"
             )
-            return@launch
+            return
         }
         javaVersionRepository.deleteVersion(version)
         actor.sendMessage("Deleted version ${version.name}")
@@ -85,11 +83,11 @@ class JavaVersionCommand(
 
     @CommandSubPath("locate <version> <path>")
     @CommandDescription("Locate an java version on the current node")
-    fun locate(
+    suspend fun locate(
         actor: ConsoleActor,
         @CommandParameter("version", true, JavaVersionSuggester::class) versionName: String,
         @CommandParameter("path", true) path: String
-    ) = defaultScope.launch {
+    ) {
         val file = File(path)
         if (file.isFile) {
             actor.sendMessage("§cThe path must be a directory")
@@ -100,7 +98,7 @@ class JavaVersionCommand(
         }
         if (!executable.exists()) {
             actor.sendMessage("§cThe path does not contain a valid java installation")
-            return@launch
+            return
         }
         var version = javaVersionRepository.getVersion(versionName)
         if (version == null) {
@@ -117,7 +115,7 @@ class JavaVersionCommand(
             )
             javaVersionRepository.createVersion(version)
             actor.sendMessage("Located version ${toConsoleValue(version.name)} at ${toConsoleValue(path)}")
-            return@launch
+            return
         }
         version.located[javaVersionRepository.serviceId.id] = file.absolutePath
         javaVersionRepository.updateVersion(version)

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ModuleCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ModuleCommand.kt
@@ -8,10 +8,8 @@ import dev.redicloud.modules.ModuleHandler
 import dev.redicloud.modules.repository.ModuleWebRepository
 import dev.redicloud.modules.suggesters.*
 import dev.redicloud.service.base.utils.ClusterConfiguration
-import dev.redicloud.utils.defaultScope
 import dev.redicloud.utils.mapTo
 import dev.redicloud.utils.toSymbol
-import kotlinx.coroutines.launch
 
 @Command("module")
 @CommandAlias(["modules"])
@@ -23,7 +21,7 @@ class ModuleCommand(
 
     @CommandSubPath("list")
     @CommandDescription("List all modules")
-    fun list(actor: ConsoleActor) = defaultScope.launch {
+    suspend fun list(actor: ConsoleActor) {
         val modules = moduleHandler.getModuleDatas()
         actor.sendHeader("Modules")
         actor.sendMessage("")
@@ -61,20 +59,20 @@ class ModuleCommand(
 
     @CommandSubPath("load <id>")
     @CommandDescription("Load a module")
-    fun load(
+    suspend fun load(
         actor: ConsoleActor,
         @CommandParameter("id", true, LoadableModulesSuggester::class) id: String
-    ) = defaultScope.launch {
+    ) {
         moduleHandler.detectModules()
         val description = moduleHandler.getModuleDescription(id)
         if (description == null) {
             actor.sendMessage("§cModule with id $id not found!")
-            return@launch
+            return
         }
         val data = moduleHandler.getModuleDatas().firstOrNull { it.description.id == id }
         if (data != null && data.loaded) {
             actor.sendMessage("§cModule with id $id is already loaded!")
-            return@launch
+            return
         }
         actor.sendMessage("Loading module %hc%${description.id}%tc%...")
         moduleHandler.loadModule(description.cachedFile!!)
@@ -82,33 +80,33 @@ class ModuleCommand(
 
     @CommandSubPath("unload <id>")
     @CommandDescription("Unload a module")
-    fun unload(
+    suspend fun unload(
         @CommandParameter("id", true, UnloadableModulesSuggester::class) id: String
-    ) = defaultScope.launch {
+    ) {
         moduleHandler.unloadModule(id)
     }
 
     @CommandSubPath("reload <id>")
     @CommandDescription("Reload a module")
     @Suppress("UnusedParameter")
-    fun reload(
+    suspend fun reload(
         actor: ConsoleActor,
         @CommandParameter("id", true, ReloadableModulesSuggester::class) id: String
-    ) = defaultScope.launch {
+    ) {
         moduleHandler.reloadModule(id)
     }
 
     @CommandSubPath("info <id>")
     @CommandDescription("Get info about a module")
-    fun info(
+    suspend fun info(
         actor: ConsoleActor,
         @CommandParameter("id", true, InstalledModulesSuggester::class) id: String
-    ) = defaultScope.launch {
+    ) {
         moduleHandler.detectModules()
         val data = moduleHandler.getModuleDatas().firstOrNull { it.description.id == id }
         if (data == null) {
             actor.sendMessage("§cModule with id $id not found!")
-            return@launch
+            return
         }
         val targetRepository = moduleHandler.getRepository(data.id)
         actor.sendHeader("Module Info")
@@ -155,7 +153,7 @@ class ModuleCommand(
         @CommandParameter("url") url: String
     ) {
         val repositoryUrls = clusterConfiguration.getList<String>("module-repositories").toMutableList()
-        if (repositoryUrls.any { it.lowercase() == url.lowercase() }) {
+        if (repositoryUrls.any { it.equals(url, ignoreCase = true) }) {
             actor.sendMessage("§cRepository with url $url already exists!")
             return
         }
@@ -177,38 +175,38 @@ class ModuleCommand(
         @CommandParameter("url") url: String
     ) {
         val repositoryUrls = clusterConfiguration.getList<String>("module-repositories").toMutableList()
-        if (!repositoryUrls.none { it.lowercase() == url.lowercase() }) {
+        if (!repositoryUrls.none { it.equals(url, ignoreCase = true) }) {
             actor.sendMessage("§cRepository with url $url not found!")
             return
         }
-        repositoryUrls.removeIf { it.lowercase() == url.lowercase() }
+        repositoryUrls.removeIf { it.equals(url, ignoreCase = true) }
         clusterConfiguration.set("module-repositories", repositoryUrls)
-        moduleHandler.repositories.removeIf { it.repoUrl.lowercase() == url.lowercase() }
+        moduleHandler.repositories.removeIf { it.repoUrl.equals(url, ignoreCase = true) }
         actor.sendMessage("§aRepository with url $url removed!")
     }
 
     @CommandSubPath("install <id>")
     @CommandDescription("Install a module")
-    fun install(
+    suspend fun install(
         @CommandParameter("id", true, InstallableModulesSuggester::class) id: String
-    ) = defaultScope.launch {
+    ) {
         moduleHandler.install(id, true)
     }
 
     @CommandSubPath("update <id>")
     @CommandDescription("Update a module")
-    fun update(
+    suspend fun update(
         actor: ConsoleActor,
         @CommandParameter("id", true, InstalledModulesSuggester::class) id: String
-    ) = defaultScope.launch {
+    ) {
         val targetRepository = moduleHandler.getRepository(id)
         if (targetRepository == null) {
             actor.sendMessage("§cModule with id $id has no repository!")
-            return@launch
+            return
         }
         if (!targetRepository.isUpdateAvailable(id)) {
             actor.sendMessage("§cModule with id $id has no update available!")
-            return@launch
+            return
         }
         actor.sendMessage("Updating module %hc%$id%tc%...")
         var file = moduleHandler.getModuleData(id)?.mapTo {
@@ -229,10 +227,10 @@ class ModuleCommand(
     @CommandSubPath("uninstall <id>")
     @CommandDescription("Uninstall a module")
     @Suppress("UnusedParameter")
-    fun uninstall(
+    suspend fun uninstall(
         actor: ConsoleActor,
         @CommandParameter("id", true, UninstallableModulesSuggester::class) id: String
-    ) = defaultScope.launch {
+    ) {
         moduleHandler.uninstall(id)
     }
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ModuleCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ModuleCommand.kt
@@ -64,17 +64,17 @@ class ModuleCommand(
     fun load(
         actor: ConsoleActor,
         @CommandParameter("id", true, LoadableModulesSuggester::class) id: String
-    ) {
+    ) = defaultScope.launch {
         moduleHandler.detectModules()
         val description = moduleHandler.getModuleDescription(id)
         if (description == null) {
             actor.sendMessage("§cModule with id $id not found!")
-            return
+            return@launch
         }
         val data = moduleHandler.getModuleDatas().firstOrNull { it.description.id == id }
         if (data != null && data.loaded) {
             actor.sendMessage("§cModule with id $id is already loaded!")
-            return
+            return@launch
         }
         actor.sendMessage("Loading module %hc%${description.id}%tc%...")
         moduleHandler.loadModule(description.cachedFile!!)
@@ -84,7 +84,7 @@ class ModuleCommand(
     @CommandDescription("Unload a module")
     fun unload(
         @CommandParameter("id", true, UnloadableModulesSuggester::class) id: String
-    ) {
+    ) = defaultScope.launch {
         moduleHandler.unloadModule(id)
     }
 
@@ -94,7 +94,7 @@ class ModuleCommand(
     fun reload(
         actor: ConsoleActor,
         @CommandParameter("id", true, ReloadableModulesSuggester::class) id: String
-    ) {
+    ) = defaultScope.launch {
         moduleHandler.reloadModule(id)
     }
 

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ServerCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ServerCommand.kt
@@ -14,9 +14,7 @@ import dev.redicloud.server.factory.ServerFactory
 import dev.redicloud.service.base.suggester.CloudServerSuggester
 import dev.redicloud.service.base.suggester.ConfigurationTemplateSuggester
 import dev.redicloud.service.base.suggester.RegisteredCloudNodeSuggester
-import dev.redicloud.utils.defaultScope
 import dev.redicloud.utils.toSymbol
-import kotlinx.coroutines.launch
 
 @Command("server")
 @CommandAlias(["ser", "s", "servers"])
@@ -48,11 +46,11 @@ class ServerCommand(
 
     @CommandSubPath("start <template> [count]")
     @CommandDescription("Queue a amount of servers with a configuration template")
-    fun start(
+    suspend fun start(
         actor: ConsoleActor,
         @CommandParameter("template", true, ConfigurationTemplateSuggester::class) template: ConfigurationTemplate,
         @CommandParameter("count", false, IntegerSuggester::class) count: Int?
-    ) = defaultScope.launch {
+    ) {
         actor.sendMessage(
             "Queued ${toConsoleValue(count ?: 1)} server with template ${toConsoleValue(template.name)}..."
         )
@@ -61,13 +59,13 @@ class ServerCommand(
 
     @CommandSubPath("startstatic <name> <id>")
     @CommandDescription("Queue a registered static server with the given name and id")
-    fun startStatic(
+    suspend fun startStatic(
         actor: ConsoleActor,
         @CommandParameter("name", true, ConfigurationTemplateSuggester::class) name: String,
         @CommandParameter("id", true, IntegerSuggester::class) id: Int
-    ) = defaultScope.launch {
+    ) {
         val server = serverRepository.getRegisteredServers().firstOrNull {
-            it.configurationTemplate.name.lowercase() == name.lowercase() && it.id == id
+            it.configurationTemplate.name.equals(name, ignoreCase = true) && it.id == id
         }
         if (server == null) {
             actor.sendMessage(
@@ -76,21 +74,21 @@ class ServerCommand(
                     false
                 )} and id ${toConsoleValue(id, false)}!"
             )
-            return@launch
+            return
         }
         if (!server.configurationTemplate.static) {
             actor.sendMessage(
                 "§cThe server ${toConsoleValue(server.identifyName(false), false)} is not a static server!"
             )
-            return@launch
+            return
         }
         if (server.state == CloudServerState.STARTING || server.state == CloudServerState.PREPARING) {
             actor.sendMessage("§cThe server ${toConsoleValue(server.identifyName(false), false)} is already starting!")
-            return@launch
+            return
         }
         if (server.state == CloudServerState.RUNNING || server.state == CloudServerState.STOPPING) {
             actor.sendMessage("§cThe server ${toConsoleValue(server.identifyName(false), false)} is already running!")
-            return@launch
+            return
         }
         actor.sendMessage("Queued static server ${server.identifyName()}...")
         serverFactory.queueStart(server.serviceId)
@@ -158,11 +156,11 @@ class ServerCommand(
 
     @CommandSubPath("stop <server> [force]")
     @CommandDescription("Stop a server")
-    fun stop(
+    suspend fun stop(
         actor: ConsoleActor,
         @CommandParameter("server", true, CloudServerSuggester::class) server: String,
         @CommandParameter("force", false, BooleanSuggester::class) force: Boolean?
-    ) = defaultScope.launch {
+    ) {
         val forceStop = force ?: false
         when {
             server == "*" -> stopAllServers(actor, forceStop)
@@ -201,14 +199,14 @@ class ServerCommand(
 
     private suspend fun stopServersByNames(actor: ConsoleActor, names: List<String>, forceStop: Boolean) {
         val servers = collectStoppableServers(forceStop)
-            .filter { server -> names.any { it.lowercase() == server.name.lowercase() } }
+            .filter { server -> names.any { it.equals(server.name, ignoreCase = true) } }
         actor.sendMessage("Stopping ${toConsoleValue(servers.size)} servers...")
         servers.forEach { serverFactory.queueStop(it.serviceId, forceStop) }
     }
 
     private suspend fun stopServerByName(actor: ConsoleActor, name: String, forceStop: Boolean) {
         val servers = collectStoppableServers(forceStop)
-            .filter { it.name.lowercase() == name.lowercase() }
+            .filter { it.name.equals(name, ignoreCase = true) }
         if (servers.isEmpty()) {
             actor.sendMessage("No server with name ${toConsoleValue(name)} connected!")
             return

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ServerCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/ServerCommand.kt
@@ -17,7 +17,6 @@ import dev.redicloud.service.base.suggester.RegisteredCloudNodeSuggester
 import dev.redicloud.utils.defaultScope
 import dev.redicloud.utils.toSymbol
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 @Command("server")
 @CommandAlias(["ser", "s", "servers"])
@@ -30,13 +29,13 @@ class ServerCommand(
 
     @CommandSubPath("list")
     @CommandDescription("List all registered servers")
-    fun list(
+    suspend fun list(
         actor: ConsoleActor
-    ) = runBlocking {
+    ) {
         val registered = serverRepository.getRegisteredServers()
         if (registered.isEmpty()) {
             actor.sendMessage("No servers are registered!")
-            return@runBlocking
+            return
         }
         actor.sendHeader("Registered servers")
         actor.sendMessage("")
@@ -99,13 +98,13 @@ class ServerCommand(
 
     @CommandSubPath("delete <server>")
     @CommandDescription("Delete a server")
-    fun delete(
+    suspend fun delete(
         actor: ConsoleActor,
         @CommandParameter("server", true, CloudServerSuggester::class) server: CloudServer
-    ) = runBlocking {
+    ) {
         if (server.state != CloudServerState.STOPPED) {
             actor.sendMessage("§cThe server ${toConsoleValue(server.name, false)} is not stopped!")
-            return@runBlocking
+            return
         }
         actor.sendMessage("Queued deletion of server ${server.identifyName()}...")
         actor.sendMessage(
@@ -116,13 +115,13 @@ class ServerCommand(
 
     @CommandSubPath("unregister <server>")
     @CommandDescription("Unregister a server (this will not delete the server files of a static server)")
-    fun unregister(
+    suspend fun unregister(
         actor: ConsoleActor,
         @CommandParameter("server", true, CloudServerSuggester::class) server: CloudServer
-    ) = runBlocking {
+    ) {
         if (server.state != CloudServerState.STOPPED) {
             actor.sendMessage("§cThe server ${toConsoleValue(server.name, false)} is not stopped!")
-            return@runBlocking
+            return
         }
         actor.sendMessage("Queued unregistration of server ${server.identifyName()}...")
         serverFactory.queueUnregister(server.serviceId)
@@ -130,14 +129,14 @@ class ServerCommand(
 
     @CommandSubPath("transfer <server> <node>")
     @CommandDescription("Transfer a static server to another node")
-    fun transfer(
+    suspend fun transfer(
         actor: ConsoleActor,
         @CommandParameter("server", true, CloudServerSuggester::class) server: CloudServer,
         @CommandParameter("node", true, RegisteredCloudNodeSuggester::class) node: CloudNode
-    ) = runBlocking {
+    ) {
         if (server.state != CloudServerState.STOPPED) {
             actor.sendMessage("§cThe server ${toConsoleValue(server.name, false)} is not stopped!")
-            return@runBlocking
+            return
         }
         if (server.hostNodeId == node.serviceId) {
             actor.sendMessage(
@@ -146,7 +145,7 @@ class ServerCommand(
                     false
                 )} is already hosted on node ${toConsoleValue(node.name, false)}!"
             )
-            return@runBlocking
+            return
         }
         actor.sendMessage(
             "Queued transfer of static server ${server.identifyName()} to node ${toConsoleValue(node.name, false)}..."
@@ -220,10 +219,10 @@ class ServerCommand(
 
     @CommandSubPath("info <server>")
     @CommandDescription("Get information about a server")
-    fun info(
+    suspend fun info(
         actor: ConsoleActor,
         @CommandParameter("server", true, CloudServerSuggester::class) server: CloudServer
-    ) = runBlocking {
+    ) {
         actor.sendHeader("Server information")
         actor.sendMessage("")
         actor.sendMessage("§8- %tc%Name§8: %hc%${server.name}")

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
@@ -11,7 +11,6 @@ import dev.redicloud.updater.Updater
 import dev.redicloud.updater.suggest.BranchSuggester
 import dev.redicloud.updater.suggest.BuildsSuggester
 import dev.redicloud.utils.*
-import kotlinx.coroutines.launch
 
 @Command("version")
 @CommandAlias(["ver"])
@@ -40,12 +39,12 @@ class VersionCommand(
 
     @CommandSubPath("checkupdate")
     @CommandDescription("Checks if an update is available")
-    fun checkUpdate(
+    suspend fun checkUpdate(
         actor: ConsoleActor
-    ) = defaultScope.launch {
+    ) {
         if (BUILD == "local") {
             actor.sendMessage("You are running a local build, updates are not available!")
-            return@launch
+            return
         }
         val updateInfo = Updater.updateAvailable()
         if (updateInfo.first && updateInfo.second != null) {
@@ -66,26 +65,26 @@ class VersionCommand(
 
     @CommandSubPath("download [branch] [build]")
     @CommandDescription("Downloads a version")
-    fun download(
+    suspend fun download(
         actor: ConsoleActor,
         @CommandParameter("branch", false, BranchSuggester::class) branchParam: String?,
         @CommandParameter("build", false, BuildsSuggester::class) buildParam: String?
-    ) = defaultScope.launch {
+    ) {
         val branch = branchParam ?: BRANCH
         val build = buildParam ?: "latest"
         val buildId = if (build == "latest") {
             val builds = Updater.getBuilds(branch)
             if (builds.isEmpty()) {
                 actor.sendMessage("§cNo builds found for the branch ${toConsoleValue(branch, false)}!")
-                return@launch
+                return
             }
             builds.filter { it.stored }.maxOfOrNull { it.build } ?: run {
                 actor.sendMessage("§cNo builds found for the branch ${toConsoleValue(branch, false)}!")
-                return@launch
+                return
             }
         } else if (build.toIntOrNull() == null) {
             actor.sendMessage("§cInvalid build number")
-            return@launch
+            return
         } else {
             build.toInt()
         }
@@ -122,34 +121,34 @@ class VersionCommand(
 
     @CommandSubPath("switch [branch] [build]")
     @CommandDescription("Switch to a downloaded version")
-    fun switch(
+    suspend fun switch(
         actor: ConsoleActor,
         @CommandParameter("branch", false, BranchSuggester::class) branchParam: String?,
         @CommandParameter("build", false, BuildsSuggester::class) buildParam: String?
-    ) = defaultScope.launch {
+    ) {
         if (Updater.updateToVersion != null) {
             actor.sendMessage("§cAn update was already installed! Restart the node service to apply the changes!")
-            return@launch
+            return
         }
         val branch = branchParam ?: BRANCH
         val build = buildParam ?: "latest"
         if (BUILD == build && BRANCH == branch) {
             actor.sendMessage("You are already running this version!")
-            return@launch
+            return
         }
         val buildId = if (build == "latest") {
             val builds = Updater.getBuilds(branch)
             if (builds.isEmpty()) {
                 actor.sendMessage("§cNo builds found for the branch ${toConsoleValue(branch, false)}!")
-                return@launch
+                return
             }
             builds.filter { it.stored }.maxOfOrNull { it.build } ?: run {
                 actor.sendMessage("§cNo builds found for the branch ${toConsoleValue(branch, false)}!")
-                return@launch
+                return
             }
         } else if (build.toIntOrNull() == null) {
             actor.sendMessage("§cInvalid build number")
-            return@launch
+            return
         } else {
             build.toInt()
         }
@@ -157,7 +156,7 @@ class VersionCommand(
         if (!installedVersions.containsKey(branch) || !installedVersions[branch]!!.contains(buildId)) {
             actor.sendMessage("§cThe version is not downloaded!")
             actor.sendMessage("§cYou can download the version with the command: %hc%version download <branch> <build>")
-            return@launch
+            return
         }
         val confirmIdentifier = Pair(branch, build)
         if (branch.lowercase() != BRANCH.lowercase() &&
@@ -172,7 +171,7 @@ class VersionCommand(
             )
             actor.sendMessage("§cType the command again to confirm!")
             switchConfirms[confirmIdentifier] = System.currentTimeMillis()
-            return@launch
+            return
         }
         if (branch == BRANCH && buildId < (BUILD.toIntOrNull() ?: -1) &&
             switchConfirms.getOrDefault(confirmIdentifier, 0) + SWITCH_CONFIRM_TIMEOUT_MS < System.currentTimeMillis()
@@ -186,7 +185,7 @@ class VersionCommand(
             )
             actor.sendMessage("§cType the command again to confirm!")
             switchConfirms[confirmIdentifier] = System.currentTimeMillis()
-            return@launch
+            return
         }
         switchConfirms.remove(confirmIdentifier)
         Updater.switchVersion(branch, buildId)
@@ -196,16 +195,16 @@ class VersionCommand(
 
     @CommandSubPath("branches")
     @CommandDescription("Displays all available branches")
-    fun branches(
+    suspend fun branches(
         actor: ConsoleActor
-    ) = defaultScope.launch {
+    ) {
         val branches = Updater.getBranches().toMutableList()
         if (BRANCH == "local") {
             branches.add("local")
         }
         if (branches.isEmpty()) {
             actor.sendMessage("§cFailed to get the branches!")
-            return@launch
+            return
         }
         actor.sendMessage("Available branches:")
         branches.forEach {
@@ -219,23 +218,23 @@ class VersionCommand(
 
     @CommandSubPath("builds [branch]")
     @CommandDescription("Displays all available builds for a branch")
-    fun builds(
+    suspend fun builds(
         actor: ConsoleActor,
         @CommandParameter("branch", false, BranchSuggester::class) branchParam: String?
-    ) = defaultScope.launch {
+    ) {
         val branch = branchParam ?: BRANCH
         val builds = mutableListOf<BuildInfo>()
         builds.addAll(Updater.getBuilds(branch))
         if (builds.isEmpty()) {
             actor.sendMessage("§cFailed to get the builds! Make sure the branch exists!")
-            return@launch
+            return
         }
         if (BRANCH == "local" && BUILD == "local") {
             builds.add(BuildInfo(BRANCH, BUILD.toIntOrNull() ?: -1, CLOUD_VERSION, -1, false))
         }
         if (builds.isEmpty()) {
             actor.sendMessage("§cNo builds found for the branch ${toConsoleValue(branch)}!")
-            return@launch
+            return
         }
         actor.sendMessage("Available builds for branch ${toConsoleValue(branch)}:")
         builds.forEach {

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
@@ -12,7 +12,6 @@ import dev.redicloud.updater.suggest.BranchSuggester
 import dev.redicloud.updater.suggest.BuildsSuggester
 import dev.redicloud.utils.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 @Command("version")
 @CommandAlias(["ver"])
@@ -252,16 +251,16 @@ class VersionCommand(
 
     @CommandSubPath("downloaded")
     @CommandDescription("Displays all downloaded versions")
-    fun downloaded(
+    suspend fun downloaded(
         actor: ConsoleActor
-    ) = runBlocking {
+    ) {
         val installedVersions = Updater.localInstalledVersions()
         if (installedVersions.isEmpty()) {
             actor.sendMessage("No versions downloaded!")
             actor.sendMessage(
                 "Use the command ${toConsoleValue("version download <branch> <build>")} to download a version!"
             )
-            return@runBlocking
+            return
         }
         actor.sendMessage("Downloaded versions:")
         installedVersions.forEach { (branch, builds) ->

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
@@ -121,6 +121,7 @@ class VersionCommand(
 
     @CommandSubPath("switch [branch] [build]")
     @CommandDescription("Switch to a downloaded version")
+    @Suppress("ReturnCount")
     suspend fun switch(
         actor: ConsoleActor,
         @CommandParameter("branch", false, BranchSuggester::class) branchParam: String?,

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/InitializeConsole.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/InitializeConsole.kt
@@ -186,7 +186,7 @@ class InitializeConsole : Console(
 
     override fun sendHeader() {
         super.sendHeader()
-        getJavaVersion() // Load versions
+        runBlocking { getJavaVersion() } // Load versions
         writeLine("§8» §fChecks§8:")
         writeLine("§f‾‾‾‾‾‾‾‾‾‾‾‾‾")
         writeLine("§8• §fLibraries §8» ${checkLibs()}")
@@ -214,8 +214,8 @@ class InitializeConsole : Console(
         }
     }
 
-    private fun checkJava(): String {
-        return if (isJavaVersionSupported(getJavaVersion())) {
+    private fun checkJava(): String = runBlocking {
+        if (isJavaVersionSupported(getJavaVersion())) {
             "§2✓ §8(§fJava: %hc%${System.getProperty("java.version")}§8)"
         } else if (isJavaVersionNotTested(getJavaVersion())) {
             "§e§l~ §8(§eJava: ${System.getProperty("java.version")}§8| §enot tested§8)"

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/InitializeConsole.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/InitializeConsole.kt
@@ -20,6 +20,7 @@ import dev.redicloud.repository.java.version.isJavaVersionNotTested
 import dev.redicloud.repository.java.version.isJavaVersionSupported
 import dev.redicloud.service.node.NodeConfiguration
 import dev.redicloud.utils.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.util.*
 import java.util.logging.Filter
@@ -228,7 +229,7 @@ class InitializeConsole : Console(
         val nodeFile = NODE_JSON.getFile()
         if (!nodeFile.exists()) {
             writeLine("Node file not found! Starting node setup in 5 seconds...")
-            Thread.sleep(SETUP_RETRY_DELAY_MS)
+            delay(SETUP_RETRY_DELAY_MS)
             return nodeSetup()
         }
         return try {
@@ -243,7 +244,7 @@ class InitializeConsole : Console(
             config
         } catch (_: Exception) {
             writeLine("§cError while reading node file! Starting node setup in 5 seconds...")
-            Thread.sleep(SETUP_RETRY_DELAY_MS)
+            delay(SETUP_RETRY_DELAY_MS)
             nodeSetup()
         }
     }
@@ -276,7 +277,7 @@ class InitializeConsole : Console(
         switchToDefaultScreen()
         emptyPrompt()
         writeLine("You finished the node setup!")
-        Thread.sleep(SETUP_COMPLETE_DELAY_MS)
+        delay(SETUP_COMPLETE_DELAY_MS)
         return config
     }
 
@@ -285,7 +286,7 @@ class InitializeConsole : Console(
         val databaseFile = DATABASE_JSON.getFile()
         if (!databaseFile.exists()) {
             writeLine("Database file not found! Starting database setup in 5 seconds...")
-            Thread.sleep(SETUP_RETRY_DELAY_MS)
+            delay(SETUP_RETRY_DELAY_MS)
             return databaseSetup()
         }
         @Suppress("TooGenericExceptionCaught")
@@ -305,14 +306,14 @@ class InitializeConsole : Console(
                 }
                 emptyPrompt()
                 writeLine("Retrying in 10 seconds...")
-                Thread.sleep(DB_RETRY_DELAY_MS)
+                delay(DB_RETRY_DELAY_MS)
                 return checkDatabase(serviceId)
             }
             return p.first
         } catch (e: Exception) {
             writeLine("§cError while reading database file! Starting database setup in 5 seconds...")
             logger.log(Level.FINE, "Reading file error: ${databaseFile.absolutePath}", e)
-            Thread.sleep(SETUP_RETRY_DELAY_MS)
+            delay(SETUP_RETRY_DELAY_MS)
             return databaseSetup()
         }
     }
@@ -346,7 +347,7 @@ class InitializeConsole : Console(
         if (useToken) {
             writeLine("§cIts currently not possible to use a token!")
             writeLine("Please enter your redis credentials manually!")
-            Thread.sleep(SETUP_COMPLETE_DELAY_MS)
+            delay(SETUP_COMPLETE_DELAY_MS)
         }
         val username: String = databaseUsernameQuestion.ask(this)
         val password: String = databasePasswordQuestion.ask(this)
@@ -374,7 +375,7 @@ class InitializeConsole : Console(
         switchToDefaultScreen()
         emptyPrompt()
         writeLine("You finished the database setup!")
-        Thread.sleep(SETUP_COMPLETE_DELAY_MS)
+        delay(SETUP_COMPLETE_DELAY_MS)
         return checkDatabase(ServiceId(UUID.randomUUID(), ServiceType.NODE))
     }
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
@@ -21,7 +21,6 @@ import dev.redicloud.repository.node.NodeRepository
 import dev.redicloud.repository.server.CloudServer
 import dev.redicloud.repository.server.ServerRepository
 import dev.redicloud.service.node.NodeConfiguration
-import dev.redicloud.utils.defaultScope
 import kotlinx.coroutines.launch
 
 @Suppress("LongMethod")
@@ -90,7 +89,7 @@ class NodeConsole(
     }
 
     override fun handleUserInterrupt(e: Exception) {
-        defaultScope.launch {
+        commandScope.launch {
             commandManager.getCommand(
                 "exit"
             )!!.getSubCommand("")!!.execute(commandManager.defaultActor, emptyList())

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
@@ -106,6 +106,10 @@ class NodeConsole(
     }
 
     override fun handleUserInterrupt(e: Exception) {
-        commandManager.getCommand("exit")!!.getSubCommand("")!!.execute(commandManager.defaultActor, emptyList())
+        runBlocking {
+            commandManager.getCommand(
+                "exit"
+            )!!.getSubCommand("")!!.execute(commandManager.defaultActor, emptyList())
+        }
     }
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
@@ -21,7 +21,8 @@ import dev.redicloud.repository.node.NodeRepository
 import dev.redicloud.repository.server.CloudServer
 import dev.redicloud.repository.server.ServerRepository
 import dev.redicloud.service.node.NodeConfiguration
-import kotlinx.coroutines.runBlocking
+import dev.redicloud.utils.defaultScope
+import kotlinx.coroutines.launch
 
 @Suppress("LongMethod")
 class NodeConsole(
@@ -89,7 +90,7 @@ class NodeConsole(
     }
 
     override fun handleUserInterrupt(e: Exception) {
-        runBlocking {
+        defaultScope.launch {
             commandManager.getCommand(
                 "exit"
             )!!.getSubCommand("")!!.execute(commandManager.defaultActor, emptyList())

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/console/NodeConsole.kt
@@ -23,6 +23,7 @@ import dev.redicloud.repository.server.ServerRepository
 import dev.redicloud.service.node.NodeConfiguration
 import kotlinx.coroutines.runBlocking
 
+@Suppress("LongMethod")
 class NodeConsole(
     nodeConfiguration: NodeConfiguration,
     eventManager: EventManager,
@@ -32,73 +33,55 @@ class NodeConsole(
 
     init {
         eventManager.listen<NodeSuspendedEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                val suspender = nodeRepository.getNode(it.suspender)
-                writeLine(
-                    "${node.identifyName()}§8: §4● §8(%tc%suspended by " +
-                        "${suspender?.identifyName(false) ?: toConsoleValue("unknown")} " +
-                        "because node is reachable§8)"
-                )
-            }
+            val node = nodeRepository.getNode(it.serviceId) ?: return@listen
+            val suspender = nodeRepository.getNode(it.suspender)
+            writeLine(
+                "${node.identifyName()}§8: §4● §8(%tc%suspended by " +
+                    "${suspender?.identifyName(false) ?: toConsoleValue("unknown")} " +
+                    "because node is reachable§8)"
+            )
         }
 
         eventManager.listen<NodeConnectEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                writeLine("${node.identifyName()}§8: §2● §8(%tc%connected to the cluster§8)")
-            }
+            val node = nodeRepository.getNode(it.serviceId) ?: return@listen
+            writeLine("${node.identifyName()}§8: §2● §8(%tc%connected to the cluster§8)")
         }
 
         eventManager.listen<NodeDisconnectEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                writeLine("${node.identifyName()}§8: §c● §8(%tc%disconnected from the cluster§8)")
-            }
+            val node = nodeRepository.getNode(it.serviceId) ?: return@listen
+            writeLine("${node.identifyName()}§8: §c● §8(%tc%disconnected from the cluster§8)")
         }
 
         eventManager.listen<NodeMasterChangedEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                writeLine("${node.identifyName()}§8: §6● §8(%tc%new master§8)")
-            }
+            val node = nodeRepository.getNode(it.serviceId) ?: return@listen
+            writeLine("${node.identifyName()}§8: §6● §8(%tc%new master§8)")
         }
 
         eventManager.listen<CloudServerConnectedEvent> {
-            runBlocking {
-                val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@runBlocking
-                writeLine("${server.identifyName()}§8: §2● §8(%tc%connected to the cluster§8)")
-            }
+            val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@listen
+            writeLine("${server.identifyName()}§8: §2● §8(%tc%connected to the cluster§8)")
         }
 
         eventManager.listen<CloudServerDisconnectedEvent> {
-            runBlocking {
-                val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@runBlocking
-                writeLine("${server.identifyName()}§8: §c● §8(%tc%disconnected from the cluster§8)")
-            }
+            val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@listen
+            writeLine("${server.identifyName()}§8: §c● §8(%tc%disconnected from the cluster§8)")
         }
 
         eventManager.listen<CloudServerDeleteEvent> {
-            runBlocking {
-                writeLine("%hc%${it.name}§8#%tc%${it.serviceId.id}§8: §4● §8(%tc%deleted§8)")
-            }
+            writeLine("%hc%${it.name}§8#%tc%${it.serviceId.id}§8: §4● §8(%tc%deleted§8)")
         }
 
         eventManager.listen<CloudServerStateChangeEvent> {
-            runBlocking {
-                val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@runBlocking
-                if (it.state == CloudServerState.PREPARING) {
-                    writeLine("${server.identifyName()}§8: §6● §8(%tc%preparing start§8)")
-                }
+            val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@listen
+            if (it.state == CloudServerState.PREPARING) {
+                writeLine("${server.identifyName()}§8: §6● §8(%tc%preparing start§8)")
             }
         }
 
         eventManager.listen<CloudServerTransferredEvent> {
-            runBlocking {
-                val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@runBlocking
-                val node = nodeRepository.getNode(server.hostNodeId) ?: return@runBlocking
-                writeLine("${server.identifyName()}§8: §5● §8(%tc%transferred to ${node.identifyName()}§8)")
-            }
+            val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@listen
+            val node = nodeRepository.getNode(server.hostNodeId) ?: return@listen
+            writeLine("${server.identifyName()}§8: §5● §8(%tc%transferred to ${node.identifyName()}§8)")
         }
 
         this.sendHeader()

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/listener/ConfigurationUpdateServerListener.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/listener/ConfigurationUpdateServerListener.kt
@@ -10,8 +10,7 @@ import dev.redicloud.api.template.configuration.ICloudConfigurationTemplateRepos
 import dev.redicloud.event.EventManager
 import dev.redicloud.repository.server.CloudServer
 import dev.redicloud.service.node.repository.node.LOGGER
-import dev.redicloud.utils.defaultScope
-import kotlinx.coroutines.launch
+
 
 class ConfigurationUpdateServerListener(
     serviceId: ServiceId,
@@ -23,29 +22,27 @@ class ConfigurationUpdateServerListener(
 
     init {
         eventManager.listen<ConfigurationTemplateUpdateEvent> {
-            defaultScope.launch {
-                val thisNode = nodeRepository.getNode(serviceId) ?: return@launch
-                if (!thisNode.master) {
-                    return@launch
-                }
-                LOGGER.info("Updating server configuration templates")
-                val configurationTemplate =
-                    configurationTemplateRepository.getTemplate(it.configurationTemplateId) ?: return@launch
-                serverRepository.getRegisteredServers()
-                    .filter { it.configurationTemplate.uniqueId == configurationTemplate.uniqueId }.forEach {
-                        if (it.state == CloudServerState.STOPPED) {
-                            (it as CloudServer).configurationTemplate = configurationTemplate
-                        } else {
-                            it.configurationTemplate.fallbackServer = configurationTemplate.fallbackServer
-                            it.configurationTemplate.joinPermission = configurationTemplate.joinPermission
-                            it.configurationTemplate.maxPlayers = configurationTemplate.maxPlayers
-                            it.configurationTemplate.percentToStartNewService =
-                                configurationTemplate.percentToStartNewService
-                            it.configurationTemplate.startPriority = configurationTemplate.startPriority
-                        }
-                        serverRepository.updateServer(it)
-                    }
+            val thisNode = nodeRepository.getNode(serviceId) ?: return@listen
+            if (!thisNode.master) {
+                return@listen
             }
+            LOGGER.info("Updating server configuration templates")
+            val configurationTemplate =
+                configurationTemplateRepository.getTemplate(it.configurationTemplateId) ?: return@listen
+            serverRepository.getRegisteredServers()
+                .filter { it.configurationTemplate.uniqueId == configurationTemplate.uniqueId }.forEach {
+                    if (it.state == CloudServerState.STOPPED) {
+                        (it as CloudServer).configurationTemplate = configurationTemplate
+                    } else {
+                        it.configurationTemplate.fallbackServer = configurationTemplate.fallbackServer
+                        it.configurationTemplate.joinPermission = configurationTemplate.joinPermission
+                        it.configurationTemplate.maxPlayers = configurationTemplate.maxPlayers
+                        it.configurationTemplate.percentToStartNewService =
+                            configurationTemplate.percentToStartNewService
+                        it.configurationTemplate.startPriority = configurationTemplate.startPriority
+                    }
+                    serverRepository.updateServer(it)
+                }
         }
     }
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/listener/ConfigurationUpdateServerListener.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/listener/ConfigurationUpdateServerListener.kt
@@ -11,7 +11,6 @@ import dev.redicloud.event.EventManager
 import dev.redicloud.repository.server.CloudServer
 import dev.redicloud.service.node.repository.node.LOGGER
 
-
 class ConfigurationUpdateServerListener(
     serviceId: ServiceId,
     eventManager: EventManager,

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/player/NodePlayerExecutor.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/player/NodePlayerExecutor.kt
@@ -7,7 +7,6 @@ import dev.redicloud.api.service.ServiceId
 import dev.redicloud.api.service.server.ICloudServer
 import dev.redicloud.api.service.server.ICloudServerRepository
 import dev.redicloud.service.base.player.BasePlayerExecutor
-import kotlinx.coroutines.runBlocking
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 
@@ -22,11 +21,11 @@ class NodePlayerExecutor(
         throw UnsupportedOperationException("Not supported for node service")
     }
 
-    override fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
-        runBlocking { this@NodePlayerExecutor.connect(cloudPlayer, server) }
+    override suspend fun executeConnect(cloudPlayer: ICloudPlayer, server: ICloudServer) {
+        throw UnsupportedOperationException("executeConnect is not supported on a node service")
     }
 
-    override fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
-        runBlocking { this@NodePlayerExecutor.kick(cloudPlayer, reason) }
+    override suspend fun executeKick(cloudPlayer: ICloudPlayer, reason: Component) {
+        throw UnsupportedOperationException("executeKick is not supported on a node service")
     }
 }

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/repository/template/file/NodeFileTemplateRepository.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/repository/template/file/NodeFileTemplateRepository.kt
@@ -15,6 +15,7 @@ import dev.redicloud.repository.node.NodeRepository
 import dev.redicloud.repository.template.file.AbstractFileTemplateRepository
 import dev.redicloud.repository.template.file.FileTemplate
 import dev.redicloud.utils.*
+import kotlinx.coroutines.CoroutineScope
 import java.io.File
 import java.util.*
 
@@ -22,8 +23,9 @@ class NodeFileTemplateRepository(
     private val databaseConnection: DatabaseConnection,
     private val nodeRepository: NodeRepository,
     private val fileCluster: FileCluster,
-    packetManager: PacketManager
-) : AbstractFileTemplateRepository(databaseConnection, nodeRepository, packetManager) {
+    packetManager: PacketManager,
+    scope: CoroutineScope
+) : AbstractFileTemplateRepository(databaseConnection, nodeRepository, packetManager, scope) {
 
     override suspend fun pushTemplates(serviceId: ServiceId) {
         val node = nodeRepository.getNode(serviceId) ?: return

--- a/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/ProxyServerService.kt
+++ b/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/ProxyServerService.kt
@@ -5,18 +5,15 @@ import dev.redicloud.api.service.ServiceType
 import dev.redicloud.repository.server.CloudMinecraftServer
 import dev.redicloud.service.minecraft.listener.AbstractCloudNotificationListeners
 import dev.redicloud.service.minecraft.listener.CloudServerListener
-import dev.redicloud.utils.coroutineExceptionHandler
-import kotlinx.coroutines.runBlocking
 
 abstract class ProxyServerService<T, S> : MinecraftServerService<T>() {
 
     protected val registeredServers: MutableMap<ServiceId, S> = mutableMapOf()
     abstract val notificationListeners: AbstractCloudNotificationListeners
 
-    init {
-        runBlocking(coroutineExceptionHandler) {
-            registerListeners()
-        }
+    override suspend fun start() {
+        super.start()
+        registerListeners()
     }
 
     abstract fun registerServer(server: CloudMinecraftServer)

--- a/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/listener/AbstractCloudNotificationListeners.kt
+++ b/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/listener/AbstractCloudNotificationListeners.kt
@@ -13,7 +13,6 @@ import dev.redicloud.api.service.node.ICloudNodeRepository
 import dev.redicloud.api.service.server.CloudServerState
 import dev.redicloud.api.service.server.ICloudServerRepository
 import dev.redicloud.repository.server.CloudServer
-import kotlinx.coroutines.runBlocking
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextComponent
 import net.kyori.adventure.text.format.NamedTextColor
@@ -25,119 +24,109 @@ abstract class AbstractCloudNotificationListeners(
 ) {
 
     init {
-        eventManager.listen<NodeSuspendedEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                val suspender = nodeRepository.getNode(it.suspender)
-                sendMessage("redicloud.node.suspend") {
-                    it.append(
-                        translateIdentifierName(node),
-                        Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content("● ").color(NamedTextColor.RED),
-                        Component.text().content("(").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content(
-                            "%tc%suspended by ${suspender?.identifyName()}"
-                        ).color(NamedTextColor.RED),
-                        Component.text().content(")").color(NamedTextColor.DARK_GRAY)
-                    )
-                }
+        eventManager.listen<NodeSuspendedEvent> { event ->
+            val node = nodeRepository.getNode(event.serviceId) ?: return@listen
+            val suspender = nodeRepository.getNode(event.suspender)
+            sendMessage("redicloud.node.suspend") {
+                it.append(
+                    translateIdentifierName(node),
+                    Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content("● ").color(NamedTextColor.RED),
+                    Component.text().content("(").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content(
+                        "%tc%suspended by ${suspender?.identifyName()}"
+                    ).color(NamedTextColor.RED),
+                    Component.text().content(")").color(NamedTextColor.DARK_GRAY)
+                )
             }
         }
 
-        eventManager.listen<NodeConnectEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                sendMessage("redicloud.node.connect") {
-                    it.append(
-                        translateIdentifierName(node),
-                        Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content("● ").color(NamedTextColor.GREEN),
-                        Component.text().content("(").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content("connected to the cluster").color(NamedTextColor.WHITE),
-                        Component.text().content(")").color(NamedTextColor.DARK_GRAY)
-                    )
-                }
+        eventManager.listen<NodeConnectEvent> { event ->
+            val node = nodeRepository.getNode(event.serviceId) ?: return@listen
+            sendMessage("redicloud.node.connect") {
+                it.append(
+                    translateIdentifierName(node),
+                    Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content("● ").color(NamedTextColor.GREEN),
+                    Component.text().content("(").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content("connected to the cluster").color(NamedTextColor.WHITE),
+                    Component.text().content(")").color(NamedTextColor.DARK_GRAY)
+                )
             }
         }
 
-        eventManager.listen<NodeDisconnectEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                sendMessage("redicloud.node.disconnect") {
-                    it.append(
-                        translateIdentifierName(node),
-                        Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content("● ").color(NamedTextColor.RED),
-                        Component.text().content("(").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content("disconnected from the cluster").color(NamedTextColor.WHITE),
-                        Component.text().content(")").color(NamedTextColor.DARK_GRAY)
-                    )
-                }
+        eventManager.listen<NodeDisconnectEvent> { event ->
+            val node = nodeRepository.getNode(event.serviceId) ?: return@listen
+            sendMessage("redicloud.node.disconnect") {
+                it.append(
+                    translateIdentifierName(node),
+                    Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content("● ").color(NamedTextColor.RED),
+                    Component.text().content("(").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content("disconnected from the cluster").color(NamedTextColor.WHITE),
+                    Component.text().content(")").color(NamedTextColor.DARK_GRAY)
+                )
             }
         }
 
-        eventManager.listen<NodeMasterChangedEvent> {
-            runBlocking {
-                val node = nodeRepository.getNode(it.serviceId) ?: return@runBlocking
-                sendMessage("redicloud.node.master.change") {
-                    it.append(
-                        translateIdentifierName(node),
-                        Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content("● ").color(NamedTextColor.YELLOW),
-                        Component.text().content("(").color(NamedTextColor.DARK_GRAY),
-                        Component.text().content("new master").color(NamedTextColor.WHITE),
-                        Component.text().content(")").color(NamedTextColor.DARK_GRAY)
-                    )
-                }
+        eventManager.listen<NodeMasterChangedEvent> { event ->
+            val node = nodeRepository.getNode(event.serviceId) ?: return@listen
+            sendMessage("redicloud.node.master.change") {
+                it.append(
+                    translateIdentifierName(node),
+                    Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content("● ").color(NamedTextColor.YELLOW),
+                    Component.text().content("(").color(NamedTextColor.DARK_GRAY),
+                    Component.text().content("new master").color(NamedTextColor.WHITE),
+                    Component.text().content(")").color(NamedTextColor.DARK_GRAY)
+                )
             }
         }
 
-        eventManager.listen<CloudServerStateChangeEvent> {
-            runBlocking {
-                val server = serverRepository.getServer<CloudServer>(it.serviceId) ?: return@runBlocking
-                when (it.state) {
-                    CloudServerState.PREPARING -> {
-                        sendMessage("redicloud.server.state.preparing") {
-                            it.append(
-                                translateIdentifierName(server),
-                                Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
-                                Component.text().content("● ").color(NamedTextColor.YELLOW),
-                                Component.text().content("(").color(NamedTextColor.DARK_GRAY),
-                                Component.text().content("preparing").color(NamedTextColor.WHITE),
-                                Component.text().content(")").color(NamedTextColor.DARK_GRAY)
-                            )
-                        }
+        eventManager.listen<CloudServerStateChangeEvent> { event ->
+            val server = serverRepository.getServer<CloudServer>(event.serviceId) ?: return@listen
+            when (event.state) {
+                CloudServerState.PREPARING -> {
+                    sendMessage("redicloud.server.state.preparing") {
+                        it.append(
+                            translateIdentifierName(server),
+                            Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
+                            Component.text().content("● ").color(NamedTextColor.YELLOW),
+                            Component.text().content("(").color(NamedTextColor.DARK_GRAY),
+                            Component.text().content("preparing").color(NamedTextColor.WHITE),
+                            Component.text().content(")").color(NamedTextColor.DARK_GRAY)
+                        )
                     }
-
-                    CloudServerState.RUNNING -> {
-                        val clickCommand = if (server.serviceId.type == ServiceType.MINECRAFT_SERVER) "/server ${server.name}" else null
-                        sendMessage("redicloud.server.state.running", clickCommand) {
-                            it.append(
-                                translateIdentifierName(server),
-                                Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
-                                Component.text().content("● ").color(NamedTextColor.GREEN),
-                                Component.text().content("(").color(NamedTextColor.DARK_GRAY),
-                                Component.text().content("started").color(NamedTextColor.WHITE),
-                                Component.text().content(")").color(NamedTextColor.DARK_GRAY)
-                            )
-                        }
-                    }
-
-                    CloudServerState.STOPPING -> {
-                        sendMessage("redicloud.server.state.stopping") {
-                            it.append(
-                                translateIdentifierName(server),
-                                Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
-                                Component.text().content("● ").color(NamedTextColor.RED),
-                                Component.text().content("(").color(NamedTextColor.DARK_GRAY),
-                                Component.text().content("stopping").color(NamedTextColor.WHITE),
-                                Component.text().content(")").color(NamedTextColor.DARK_GRAY)
-                            )
-                        }
-                    }
-
-                    else -> return@runBlocking
                 }
+
+                CloudServerState.RUNNING -> {
+                    val clickCommand = if (server.serviceId.type == ServiceType.MINECRAFT_SERVER) "/server ${server.name}" else null
+                    sendMessage("redicloud.server.state.running", clickCommand) {
+                        it.append(
+                            translateIdentifierName(server),
+                            Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
+                            Component.text().content("● ").color(NamedTextColor.GREEN),
+                            Component.text().content("(").color(NamedTextColor.DARK_GRAY),
+                            Component.text().content("started").color(NamedTextColor.WHITE),
+                            Component.text().content(")").color(NamedTextColor.DARK_GRAY)
+                        )
+                    }
+                }
+
+                CloudServerState.STOPPING -> {
+                    sendMessage("redicloud.server.state.stopping") {
+                        it.append(
+                            translateIdentifierName(server),
+                            Component.text().content(": ").color(NamedTextColor.DARK_GRAY),
+                            Component.text().content("● ").color(NamedTextColor.RED),
+                            Component.text().content("(").color(NamedTextColor.DARK_GRAY),
+                            Component.text().content("stopping").color(NamedTextColor.WHITE),
+                            Component.text().content(")").color(NamedTextColor.DARK_GRAY)
+                        )
+                    }
+                }
+
+                else -> return@listen
             }
         }
     }

--- a/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/listener/CloudServerListener.kt
+++ b/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/listener/CloudServerListener.kt
@@ -5,8 +5,7 @@ import dev.redicloud.api.events.internal.server.CloudServerDisconnectedEvent
 import dev.redicloud.api.events.listen
 import dev.redicloud.api.service.ServiceType
 import dev.redicloud.service.minecraft.ProxyServerService
-import dev.redicloud.utils.defaultScope
-import kotlinx.coroutines.launch
+
 
 class CloudServerListener(
     private val proxyServerService: ProxyServerService<*, *>
@@ -14,12 +13,10 @@ class CloudServerListener(
 
     init {
         proxyServerService.eventManager.listen<CloudServerConnectedEvent> {
-            defaultScope.launch {
-                if (it.serviceId.type != ServiceType.MINECRAFT_SERVER) return@launch
-                val server = proxyServerService.serverRepository.getMinecraftServer(it.serviceId)
-                    ?: error("Cant register server that is not in the repository: ${it.serviceId.toName()}")
-                proxyServerService.registerServer(server)
-            }
+            if (it.serviceId.type != ServiceType.MINECRAFT_SERVER) return@listen
+            val server = proxyServerService.serverRepository.getMinecraftServer(it.serviceId)
+                ?: error("Cant register server that is not in the repository: ${it.serviceId.toName()}")
+            proxyServerService.registerServer(server)
         }
 
         proxyServerService.eventManager.listen<CloudServerDisconnectedEvent> {

--- a/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/listener/CloudServerListener.kt
+++ b/services/proxy-server-service/src/main/kotlin/dev/redicloud/service/minecraft/listener/CloudServerListener.kt
@@ -6,7 +6,6 @@ import dev.redicloud.api.events.listen
 import dev.redicloud.api.service.ServiceType
 import dev.redicloud.service.minecraft.ProxyServerService
 
-
 class CloudServerListener(
     private val proxyServerService: ProxyServerService<*, *>
 ) {

--- a/tasks/src/main/kotlin/dev/redicloud/tasks/CloudTask.kt
+++ b/tasks/src/main/kotlin/dev/redicloud/tasks/CloudTask.kt
@@ -3,7 +3,6 @@ package dev.redicloud.tasks
 import dev.redicloud.tasks.executor.CloudTaskExecutor
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.*
 import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
@@ -35,8 +34,8 @@ abstract class CloudTask(private val useLock: Boolean = true) {
                     Level.FINEST,
                     "Cloud task ${this@CloudTask::class.simpleName} execute by ${source::class.simpleName}"
                 )
-                if (runBlocking { execute() }) {
-                    runBlocking { cancel() }
+                if (execute()) {
+                    cancel()
                 }
             } catch (e: Exception) {
                 CloudTaskManager.LOGGER.log(

--- a/tasks/src/main/kotlin/dev/redicloud/tasks/CloudTask.kt
+++ b/tasks/src/main/kotlin/dev/redicloud/tasks/CloudTask.kt
@@ -3,8 +3,9 @@ package dev.redicloud.tasks
 import dev.redicloud.tasks.executor.CloudTaskExecutor
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.*
-import java.util.concurrent.locks.ReentrantLock
 import java.util.logging.Level
 
 abstract class CloudTask(private val useLock: Boolean = true) {
@@ -16,7 +17,7 @@ abstract class CloudTask(private val useLock: Boolean = true) {
     private var started = false
     lateinit var taskManager: CloudTaskManager
     private val finishListener = mutableListOf<() -> Unit>()
-    private val lock = ReentrantLock()
+    private val mutex = Mutex()
 
     abstract suspend fun execute(): Boolean
 
@@ -25,29 +26,29 @@ abstract class CloudTask(private val useLock: Boolean = true) {
         return taskManager.scope.launch {
             executeCount++
             if (canceled) return@launch
-            if (useLock) {
-                lock.lock()
+            val block: suspend () -> Unit = {
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    CloudTaskManager.LOGGER.log(
+                        Level.FINEST,
+                        "Cloud task ${this@CloudTask::class.simpleName} execute by ${source::class.simpleName}"
+                    )
+                    if (execute()) {
+                        cancel()
+                    }
+                } catch (e: Exception) {
+                    CloudTaskManager.LOGGER.log(
+                        Level.SEVERE,
+                        "Error while executing cloud task " +
+                            "(${this@CloudTask::class.simpleName}) by ${source::class.simpleName}",
+                        e
+                    )
+                }
             }
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                CloudTaskManager.LOGGER.log(
-                    Level.FINEST,
-                    "Cloud task ${this@CloudTask::class.simpleName} execute by ${source::class.simpleName}"
-                )
-                if (execute()) {
-                    cancel()
-                }
-            } catch (e: Exception) {
-                CloudTaskManager.LOGGER.log(
-                    Level.SEVERE,
-                    "Error while executing cloud task " +
-                        "(${this@CloudTask::class.simpleName}) by ${source::class.simpleName}",
-                    e
-                )
-            } finally {
-                if (useLock) {
-                    lock.unlock()
-                }
+            if (useLock) {
+                mutex.withLock { block() }
+            } else {
+                block()
             }
         }
     }

--- a/tasks/src/main/kotlin/dev/redicloud/tasks/CloudTaskManager.kt
+++ b/tasks/src/main/kotlin/dev/redicloud/tasks/CloudTaskManager.kt
@@ -14,6 +14,7 @@ import dev.redicloud.tasks.executor.PeriodicallyCloudTaskExecutor
 import dev.redicloud.utils.coroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.newFixedThreadPoolContext
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -34,7 +35,7 @@ class CloudTaskManager(
 
     @OptIn(DelicateCoroutinesApi::class)
     internal val scope = CoroutineScope(
-        newFixedThreadPoolContext(threads, "CloudTaskManager") + coroutineExceptionHandler
+        SupervisorJob() + newFixedThreadPoolContext(threads, "CloudTaskManager") + coroutineExceptionHandler
     )
 
     fun register(task: CloudTask): UUID {

--- a/updater/src/main/kotlin/dev/redicloud/updater/suggest/BranchSuggester.kt
+++ b/updater/src/main/kotlin/dev/redicloud/updater/suggest/BranchSuggester.kt
@@ -3,10 +3,8 @@ package dev.redicloud.updater.suggest
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.updater.Updater
-import kotlinx.coroutines.runBlocking
 
 class BranchSuggester : AbstractCommandSuggester() {
-    override fun suggest(context: CommandContext): Array<String> = runBlocking {
-        return@runBlocking Updater.getBranches().toTypedArray()
-    }
+    override suspend fun suggest(context: CommandContext): Array<String> =
+        Updater.getBranches().toTypedArray()
 }

--- a/updater/src/main/kotlin/dev/redicloud/updater/suggest/BuildsSuggester.kt
+++ b/updater/src/main/kotlin/dev/redicloud/updater/suggest/BuildsSuggester.kt
@@ -3,12 +3,11 @@ package dev.redicloud.updater.suggest
 import dev.redicloud.api.commands.AbstractCommandSuggester
 import dev.redicloud.api.commands.CommandContext
 import dev.redicloud.updater.Updater
-import kotlinx.coroutines.runBlocking
 
 class BuildsSuggester : AbstractCommandSuggester() {
-    override fun suggest(context: CommandContext): Array<String> = runBlocking {
-        val branch = context.input.split(" ").lastOrNull { it.isNotBlank() } ?: return@runBlocking arrayOf("latest")
-        return@runBlocking Updater.getBuilds(branch).map { it.build.toString() }.also {
+    override suspend fun suggest(context: CommandContext): Array<String> {
+        val branch = context.input.split(" ").lastOrNull { it.isNotBlank() } ?: return arrayOf("latest")
+        return Updater.getBuilds(branch).map { it.build.toString() }.also {
             it.toMutableList().add("latest")
         }.toTypedArray()
     }

--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -18,4 +18,5 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines)
+    testRuntimeOnly(project(":logging"))
 }

--- a/utils/src/main/kotlin/dev/redicloud/utils/ConcurrentBatch.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/ConcurrentBatch.kt
@@ -2,7 +2,7 @@ package dev.redicloud.utils
 
 import kotlinx.coroutines.*
 
-class MultiAsyncAction(
+class ConcurrentBatch(
     dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) {
 
@@ -11,16 +11,14 @@ class MultiAsyncAction(
     private val jobs = mutableListOf<Job>()
 
     fun add(action: suspend () -> Unit) {
-        runBlocking { actions.add(action) }
+        actions.add(action)
     }
 
     suspend fun joinAll() {
-        runBlocking {
-            actions.forEach {
-                jobs.add(scope.launch { it() })
-            }
-            jobs.joinAll()
-            scope.cancel()
+        actions.forEach {
+            jobs.add(scope.launch { it() })
         }
+        jobs.joinAll()
+        scope.cancel()
     }
 }

--- a/utils/src/main/kotlin/dev/redicloud/utils/CoroutinesConstants.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/CoroutinesConstants.kt
@@ -12,5 +12,8 @@ val coroutineExceptionHandler = CoroutineExceptionHandler { coroutineContext, th
     threadLogger.severe("Caught exception in coroutine-context: $coroutineContext", throwable)
 }
 
+@Deprecated("Use a service-scoped CoroutineScope instead", ReplaceWith("serviceScope"))
 val defaultScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + coroutineExceptionHandler)
+
+@Deprecated("Use a service-scoped CoroutineScope instead", ReplaceWith("serviceScope"))
 val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO + coroutineExceptionHandler)

--- a/utils/src/main/kotlin/dev/redicloud/utils/CoroutinesConstants.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/CoroutinesConstants.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 val threadLogger = LogManager.logger("Coroutines")
 
@@ -17,3 +19,11 @@ val defaultScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + corout
 
 @Deprecated("Use a service-scoped CoroutineScope instead", ReplaceWith("serviceScope"))
 val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO + coroutineExceptionHandler)
+
+/**
+ * Conditionally acquires the mutex before executing [action].
+ * Used as a re-entrancy workaround: callers pass `lock = false` when the mutex is already held.
+ */
+suspend inline fun <T> Mutex.withOptionalLock(lock: Boolean, action: () -> T): T {
+    return if (lock) withLock { action() } else action()
+}

--- a/utils/src/main/kotlin/dev/redicloud/utils/CoroutinesConstants.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/CoroutinesConstants.kt
@@ -4,6 +4,7 @@ import dev.redicloud.logging.LogManager
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 val threadLogger = LogManager.logger("Coroutines")
 
@@ -11,5 +12,5 @@ val coroutineExceptionHandler = CoroutineExceptionHandler { coroutineContext, th
     threadLogger.severe("Caught exception in coroutine-context: $coroutineContext", throwable)
 }
 
-val defaultScope = CoroutineScope(Dispatchers.Default + coroutineExceptionHandler)
-val ioScope = CoroutineScope(Dispatchers.IO + coroutineExceptionHandler)
+val defaultScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + coroutineExceptionHandler)
+val ioScope = CoroutineScope(SupervisorJob() + Dispatchers.IO + coroutineExceptionHandler)

--- a/utils/src/main/kotlin/dev/redicloud/utils/EasyCache.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/EasyCache.kt
@@ -10,6 +10,7 @@ open class EasyCache<T, I>(
 ) {
 
     private val cachedValues: ConcurrentHashMap<I, Pair<Long, T?>> = ConcurrentHashMap()
+
     @Volatile
     private var singleCachedValue: Pair<Long, T?>? = null
 

--- a/utils/src/main/kotlin/dev/redicloud/utils/EasyCache.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/EasyCache.kt
@@ -1,6 +1,7 @@
 package dev.redicloud.utils
 
 import kotlinx.coroutines.runBlocking
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration
 
 open class EasyCache<T, I>(
@@ -8,15 +9,22 @@ open class EasyCache<T, I>(
     val block: suspend (I?) -> T?
 ) {
 
-    private var cachedValues: MutableMap<I, Pair<Long, T?>> = mutableMapOf()
+    private val cachedValues: ConcurrentHashMap<I, Pair<Long, T?>> = ConcurrentHashMap()
+    @Volatile
     private var singleCachedValue: Pair<Long, T?>? = null
 
-    fun get(key: I? = null): T? {
+    suspend fun get(key: I? = null): T? {
         if (!isCacheValid(key)) {
-            setCached(key, runBlocking { block(key) })
+            setCached(key, block(key))
         }
         return getCached(key)
     }
+
+    /**
+     * Blocking bridge for non-suspend callers. Prefer [get] in coroutine contexts.
+     * Should be removed once all callers support suspend.
+     */
+    fun getBlocking(key: I? = null): T? = runBlocking { get(key) }
 
     fun isCached(key: I?): Boolean {
         if (key == null) return singleCachedValue != null

--- a/utils/src/main/kotlin/dev/redicloud/utils/MultiAsyncAction.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/MultiAsyncAction.kt
@@ -6,7 +6,7 @@ class MultiAsyncAction(
     dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) {
 
-    private val scope = CoroutineScope(dispatcher + coroutineExceptionHandler)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher + coroutineExceptionHandler)
     private val actions = mutableListOf<suspend () -> Unit>()
     private val jobs = mutableListOf<Job>()
 

--- a/utils/src/main/kotlin/dev/redicloud/utils/SimpleLock.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/SimpleLock.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.Condition
 import java.util.concurrent.locks.Lock
 
+@Deprecated("Use kotlinx.coroutines.sync.Mutex instead", ReplaceWith("Mutex()", "kotlinx.coroutines.sync.Mutex"))
 class SimpleLock : Lock {
 
     private val state = AtomicBoolean(false)

--- a/utils/src/test/kotlin/dev/redicloud/utils/ConcurrentBatchTest.kt
+++ b/utils/src/test/kotlin/dev/redicloud/utils/ConcurrentBatchTest.kt
@@ -1,23 +1,25 @@
 package dev.redicloud.utils
 
 import kotlinx.coroutines.runBlocking
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class ConcurrentBatchTest : UtilTest() {
 
     @Test
     fun joinAllTest() {
-        val taskStates = mutableMapOf<String, Boolean>()
+        val taskStates = ConcurrentHashMap<String, Boolean>()
         val batch = ConcurrentBatch()
         for (i in 0..10) {
             batch.add {
-                taskStates[i.toString()] = false
+                taskStates[i.toString()] = true
                 Thread.sleep(randomIntInRange(100, 1000).toLong())
             }
         }
         runBlocking { batch.joinAll() }
         for (i in 0..10) {
-            assert(taskStates[i.toString()] == false)
+            assertTrue(taskStates[i.toString()] == true, "Task $i did not execute")
         }
     }
 }

--- a/utils/src/test/kotlin/dev/redicloud/utils/ConcurrentBatchTest.kt
+++ b/utils/src/test/kotlin/dev/redicloud/utils/ConcurrentBatchTest.kt
@@ -3,19 +3,19 @@ package dev.redicloud.utils
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 
-class MultiAsyncActionTest : UtilTest() {
+class ConcurrentBatchTest : UtilTest() {
 
     @Test
     fun joinAllTest() {
         val taskStates = mutableMapOf<String, Boolean>()
-        val multiAsyncAction = MultiAsyncAction()
+        val batch = ConcurrentBatch()
         for (i in 0..10) {
-            multiAsyncAction.add {
+            batch.add {
                 taskStates[i.toString()] = false
                 Thread.sleep(randomIntInRange(100, 1000).toLong())
             }
         }
-        runBlocking { multiAsyncAction.joinAll() }
+        runBlocking { batch.joinAll() }
         for (i in 0..10) {
             assert(taskStates[i.toString()] == false)
         }

--- a/utils/src/test/kotlin/dev/redicloud/utils/EasyCacheTest.kt
+++ b/utils/src/test/kotlin/dev/redicloud/utils/EasyCacheTest.kt
@@ -1,5 +1,6 @@
 package dev.redicloud.utils
 
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
@@ -7,13 +8,13 @@ import kotlin.time.Duration.Companion.seconds
 class EasyCacheTest : UtilTest() {
 
     @Test
-    fun testGet() {
+    fun testGet() = runBlocking {
         val cache = SingleCache(10.seconds) { "test" }
         assertEquals("test", cache.get(), "Cache should return the value")
     }
 
     @Test
-    fun testTimeout() {
+    fun testTimeout() = runBlocking {
         var getCount = 0
         val cache = SingleCache(1.seconds) {
             getCount++
@@ -26,7 +27,7 @@ class EasyCacheTest : UtilTest() {
     }
 
     @Test
-    fun testCache() {
+    fun testCache() = runBlocking {
         var getCount = 0
         val cache = SingleCache(5.seconds) {
             getCount++


### PR DESCRIPTION
Full refactor of the coroutine infrastructure to eliminate runBlocking, thread starvation risks, and unstructured concurrency across the entire codebase.

### Core Infrastructure
- Add SupervisorJob to all coroutine scopes for fault isolation
- Add service-scoped CoroutineScope to BaseService, replacing global defaultScope/ioScope
- Deprecate global scopes; migrate all usages to service-scoped scopes
- Rename MultiAsyncAction to ConcurrentBatch and remove internal runBlocking

### Blocking Call Elimination
- Remove runBlocking from event listeners, cloud task execution, command handlers, REST module, server process exit handler, file cluster, and player executors
- Wrap blocking file/network I/O (ProcessBuilder.start(), Process.waitFor(), file operations) with withContext(Dispatchers.IO)
- Replace Thread.sleep with delay in coroutine contexts
- Replace runCatching with cancellation-safe try/catch (avoids swallowing CancellationException)

### Suspend Migration
- Make event system fully suspend-aware with suspend handlers
- Migrate packet framework to suspend
- Make command handlers, argument parsers, and suggesters suspend
- Make executeConnect/executeKick in player executors suspend
- Extract connector and node-service init blocks into suspend fun start()

### Lock Migration
- Replace Java ReentrantLock with coroutine Mutex
- Replace manual mutex.lock()/unlock() with withLock/withOptionalLock
- Fix: use Kotlin lock instead of Java lock

### Other
- Make EasyCache suspend and thread-safe
- Extract PacketManager.connect(), inject scope into cache layer
- Fix console polling to avoid blocking
- Replace runBlocking with EventTask in Velocity event listeners

_Issues were identified by Claude Opus 4.6_