### PR TITLE
refactor: signed release manifest & connector migration to github releases

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -99,24 +99,72 @@ jobs:
           zip -r "../redicloud-${{ steps.version.outputs.full }}.zip" .
           cd ..
 
-      # --- Checksums ---
-      - name: Generate SHA256 checksums
+      # --- Generate manifest ---
+      - name: Generate release manifest
         run: |
-          sha256sum "redicloud-${{ steps.version.outputs.full }}.zip" > checksums.sha256
-          cd export
-          sha256sum **/*.jar >> ../checksums.sha256
-          cd ..
+          VERSION="${{ steps.version.outputs.base }}"
+          FULL="${{ steps.version.outputs.full }}"
+          DISPLAY="${{ steps.version.outputs.display }}"
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          ZIP_NAME="redicloud-${FULL}.zip"
+
+          # Start JSON
+          cat > manifest.json <<MANIFEST_HEAD
+          {
+            "version": "${VERSION}",
+            "fullVersion": "${FULL}",
+            "channel": "beta",
+            "timestamp": "${TIMESTAMP}",
+            "minJavaVersion": 21,
+            "artifacts": {
+          MANIFEST_HEAD
+
+          # Collect artifacts: zip + all JARs in export/
+          FIRST=true
+          for file in "$ZIP_NAME" $(find export -name '*.jar' | sort); do
+            HASH=$(sha256sum "$file" | awk '{print $1}')
+            SIZE=$(stat --printf="%s" "$file")
+
+            # Determine artifact type and key
+            if [[ "$file" == *.zip ]]; then
+              KEY="$file"
+              TYPE="distribution"
+            elif [[ "$file" == *connector* ]]; then
+              KEY="${file#export/}"
+              TYPE="connector"
+            elif [[ "$file" == *node-service* ]]; then
+              KEY="${file#export/}"
+              TYPE="service"
+            else
+              KEY="${file#export/}"
+              TYPE="module"
+            fi
+
+            if $FIRST; then
+              FIRST=false
+            else
+              echo "," >> manifest.json
+            fi
+            printf '    "%s": {"sha256": "%s", "size": %s, "type": "%s"}' \
+              "$KEY" "$HASH" "$SIZE" "$TYPE" >> manifest.json
+          done
+
+          # Close JSON
+          cat >> manifest.json <<'MANIFEST_TAIL'
+
+            }
+          }
+          MANIFEST_TAIL
 
       # --- GPG signing ---
-      - name: GPG sign checksums
+      - name: GPG sign manifest
         if: ${{ env.GPG_PRIVATE_KEY != '' }}
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-          # Sign the checksums file (public key is embedded in the binary, not uploaded)
           gpg --batch --yes --pinentry-mode loopback \
-            --detach-sign --armor checksums.sha256
+            --detach-sign --armor manifest.json
 
       # --- Publish to GitHub Packages ---
       - name: Publish Maven artifacts
@@ -191,7 +239,7 @@ jobs:
             echo '```'
             echo ""
             echo "### Verification"
-            echo "SHA-256 checksums and GPG signature are included as release assets."
+            echo "A signed release manifest (\`manifest.json\` + \`manifest.json.asc\`) is included as release asset."
             echo '```'
             echo "Signing key fingerprint: ${FINGERPRINT}"
             echo '```'
@@ -214,6 +262,7 @@ jobs:
           prerelease: true
           files: |
             redicloud-${{ steps.version.outputs.full }}.zip
-            checksums.sha256
-            checksums.sha256.asc
+            manifest.json
+            manifest.json.asc
+            export/connectors/*.jar
           fail_on_unmatched_files: false

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -93,24 +93,71 @@ jobs:
           zip -r "../redicloud-${{ steps.version.outputs.full }}.zip" .
           cd ..
 
-      # --- Checksums ---
-      - name: Generate SHA256 checksums
+      # --- Generate manifest ---
+      - name: Generate release manifest
         run: |
-          sha256sum "redicloud-${{ steps.version.outputs.full }}.zip" > checksums.sha256
-          cd export
-          sha256sum **/*.jar >> ../checksums.sha256
-          cd ..
+          VERSION="${{ steps.version.outputs.base }}"
+          FULL="${{ steps.version.outputs.full }}"
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          ZIP_NAME="redicloud-${FULL}.zip"
+
+          # Start JSON
+          cat > manifest.json <<MANIFEST_HEAD
+          {
+            "version": "${VERSION}",
+            "fullVersion": "${FULL}",
+            "channel": "stable",
+            "timestamp": "${TIMESTAMP}",
+            "minJavaVersion": 21,
+            "artifacts": {
+          MANIFEST_HEAD
+
+          # Collect artifacts: zip + all JARs in export/
+          FIRST=true
+          for file in "$ZIP_NAME" $(find export -name '*.jar' | sort); do
+            HASH=$(sha256sum "$file" | awk '{print $1}')
+            SIZE=$(stat --printf="%s" "$file")
+
+            # Determine artifact type and key
+            if [[ "$file" == *.zip ]]; then
+              KEY="$file"
+              TYPE="distribution"
+            elif [[ "$file" == *connector* ]]; then
+              KEY="${file#export/}"
+              TYPE="connector"
+            elif [[ "$file" == *node-service* ]]; then
+              KEY="${file#export/}"
+              TYPE="service"
+            else
+              KEY="${file#export/}"
+              TYPE="module"
+            fi
+
+            if $FIRST; then
+              FIRST=false
+            else
+              echo "," >> manifest.json
+            fi
+            printf '    "%s": {"sha256": "%s", "size": %s, "type": "%s"}' \
+              "$KEY" "$HASH" "$SIZE" "$TYPE" >> manifest.json
+          done
+
+          # Close JSON
+          cat >> manifest.json <<'MANIFEST_TAIL'
+
+            }
+          }
+          MANIFEST_TAIL
 
       # --- GPG signing ---
-      - name: GPG sign checksums
+      - name: GPG sign manifest
         if: ${{ env.GPG_PRIVATE_KEY != '' }}
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-          # Sign the checksums file (public key is embedded in the binary, not uploaded)
           gpg --batch --yes --pinentry-mode loopback \
-            --detach-sign --armor checksums.sha256
+            --detach-sign --armor manifest.json
 
       # --- Publish to GitHub Packages ---
       - name: Publish Maven artifacts
@@ -182,7 +229,7 @@ jobs:
             echo '```'
             echo ""
             echo "### Verification"
-            echo "SHA-256 checksums and GPG signature are included as release assets."
+            echo "A signed release manifest (\`manifest.json\` + \`manifest.json.asc\`) is included as release asset."
             echo '```'
             echo "Signing key fingerprint: ${FINGERPRINT}"
             echo '```'
@@ -205,6 +252,7 @@ jobs:
           prerelease: false
           files: |
             redicloud-${{ steps.version.outputs.full }}.zip
-            checksums.sha256
-            checksums.sha256.asc
+            manifest.json
+            manifest.json.asc
+            export/connectors/*.jar
           fail_on_unmatched_files: false

--- a/api-files/server-version-types.json
+++ b/api-files/server-version-types.json
@@ -29,8 +29,8 @@
         "secret": "'%PROXY_SECRET%'"
       }
     },
-    "connectorPluginName": "redicloud-bukkit-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-bukkit-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-bukkit-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-bukkit-connector-%cloud_version%.jar",
     "connectorFolder": "plugins",
     "libPattern": "(cache|versions|libraries)"
   },
@@ -60,8 +60,8 @@
         "max-players": "%MAX_PLAYERS%"
       }
     },
-    "connectorPluginName": "redicloud-bukkit-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-bukkit-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-bukkit-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-bukkit-connector-%cloud_version%.jar",
     "connectorFolder": "plugins",
     "libPattern": "(bundler)"
   },
@@ -87,8 +87,8 @@
         "": "%PROXY_SECRET%"
       }
     },
-    "connectorPluginName": "redicloud-velocity-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-velocity-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-velocity-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-velocity-connector-%cloud_version%.jar",
     "connectorFolder": "plugins",
     "libPattern": null
   },
@@ -110,8 +110,8 @@
         "player_limit": "%MAX_PLAYERS%"
       }
     },
-    "connectorPluginName": "redicloud-bungeecord-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-bungeecord-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-bungeecord-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-bungeecord-connector-%cloud_version%.jar",
     "connectorFolder": "plugins"
   },
   {
@@ -132,8 +132,8 @@
         "player_limit": "%MAX_PLAYERS%"
       }
     },
-    "connectorPluginName": "redicloud-bungeecord-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-bungeecord-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-bungeecord-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-bungeecord-connector-%cloud_version%.jar",
     "connectorFolder": "plugins",
     "libPattern": null
   },
@@ -161,8 +161,8 @@
         "max-players": "%MAX_PLAYERS%"
       }
     },
-    "connectorPluginName": "redicloud-bukkit-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-bukkit-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-bukkit-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-bukkit-connector-%cloud_version%.jar",
     "connectorFolder": "plugins",
     "libPattern": "(cache|versions|libraries)"
   },
@@ -177,8 +177,8 @@
     "environmentVariables": {},
     "defaultFiles": [],
     "fileEdits": {},
-    "connectorPluginName": "redicloud-minestom-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-minestom-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-minestom-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-minestom-connector-%cloud_version%.jar",
     "connectorFolder": "extensions",
     "libPattern": null
   },
@@ -193,8 +193,8 @@
     "environmentVariables": {},
     "defaultFiles": [],
     "fileEdits": {},
-    "connectorPluginName": "redicloud-limbo-connector-%cloud_version%-%branch%-%build%.jar",
-    "connectorDownloadUrl": "https://api.redicloud.dev/v2/files/%branch%/%build%/connectors/redicloud-limbo-connector-%cloud_version%-%branch%-%build%.jar",
+    "connectorPluginName": "redicloud-limbo-connector-%cloud_version%.jar",
+    "connectorDownloadUrl": "https://github.com/RediCloud/cloud-v2/releases/download/v%cloud_version%/redicloud-limbo-connector-%cloud_version%.jar",
     "connectorFolder": "plugins",
     "libPattern": null
   }

--- a/apis/base-api/src/main/kotlin/dev/redicloud/api/version/ICloudServerVersionType.kt
+++ b/apis/base-api/src/main/kotlin/dev/redicloud/api/version/ICloudServerVersionType.kt
@@ -16,6 +16,8 @@ interface ICloudServerVersionType : ProcessConfiguration {
     var connectorDownloadUrl: String?
     var connectorFolder: String
     var libPattern: String?
+    /** Optional SHA-256 hash for custom connector integrity verification. */
+    var connectorSha256: String?
 
     fun getParsedConnectorFile(nodeFolder: Boolean): File
 

--- a/install.sh
+++ b/install.sh
@@ -210,7 +210,7 @@ if $VERIFY && [[ -n "${MANIFEST_URL:-}" ]]; then
         # The zip key contains the full filename; we search for its sha256 value.
         ZIP_ASSET_NAME=$(basename "$ZIP_URL")
         EXPECTED=$(awk -v name="$ZIP_ASSET_NAME" '
-            $0 ~ "\"" name "\"" { found=1 }
+            index($0, "\"" name "\"") > 0 { found=1 }
             found && /"sha256"/ {
                 gsub(/.*"sha256"[[:space:]]*:[[:space:]]*"/, "")
                 gsub(/".*/, "")

--- a/install.sh
+++ b/install.sh
@@ -174,8 +174,8 @@ resolve_release() {
     assets=$(echo "$release_json" | json_assets)
 
     ZIP_URL=$(echo "$assets" | awk -F'\t' '/\.zip\t/ { print $2; exit }')
-    CHECKSUMS_URL=$(echo "$assets" | awk -F'\t' '$1 == "checksums.sha256" { print $2; exit }')
-    SIGNATURE_URL=$(echo "$assets" | awk -F'\t' '$1 == "checksums.sha256.asc" { print $2; exit }')
+    MANIFEST_URL=$(echo "$assets" | awk -F'\t' '$1 == "manifest.json" { print $2; exit }')
+    SIGNATURE_URL=$(echo "$assets" | awk -F'\t' '$1 == "manifest.json.asc" { print $2; exit }')
 
     [[ -z "$ZIP_URL" ]] && fail "No zip asset found in release $TAG_NAME"
 }
@@ -199,30 +199,40 @@ ZIP_SIZE=$(du -h "$ZIP_FILE" | cut -f1)
 ok "Downloaded redicloud ($ZIP_SIZE)"
 
 # ─────────────────────────────────────────────────────────────────────
-# Checksum verification
+# Manifest-based checksum verification
 # ─────────────────────────────────────────────────────────────────────
 
-CHECKSUMS_FILE="$TMPDIR/checksums.sha256"
+MANIFEST_FILE="$TMPDIR/manifest.json"
 
-if $VERIFY && [[ -n "${CHECKSUMS_URL:-}" ]]; then
-    if curl -fsSL -o "$CHECKSUMS_FILE" "$CHECKSUMS_URL" 2>/dev/null; then
+if $VERIFY && [[ -n "${MANIFEST_URL:-}" ]]; then
+    if curl -fsSL -o "$MANIFEST_FILE" "$MANIFEST_URL" 2>/dev/null; then
+        # Extract the sha256 for the zip asset from the manifest JSON.
+        # The zip key contains the full filename; we search for its sha256 value.
         ZIP_ASSET_NAME=$(basename "$ZIP_URL")
-        EXPECTED=$(grep "$ZIP_ASSET_NAME" "$CHECKSUMS_FILE" | awk '{print $1}' || true)
+        EXPECTED=$(awk -v name="$ZIP_ASSET_NAME" '
+            $0 ~ "\"" name "\"" { found=1 }
+            found && /"sha256"/ {
+                gsub(/.*"sha256"[[:space:]]*:[[:space:]]*"/, "")
+                gsub(/".*/, "")
+                print
+                exit
+            }
+        ' "$MANIFEST_FILE")
 
         if [[ -n "$EXPECTED" ]]; then
             ACTUAL=$(sha256sum "$ZIP_FILE" | awk '{print $1}')
             if [[ "$ACTUAL" != "$EXPECTED" ]]; then
                 fail "Checksum mismatch! Expected: $EXPECTED, Got: $ACTUAL"
             fi
-            ok "SHA256 checksum verified"
+            ok "SHA-256 checksum verified (from manifest)"
         else
-            warn "No checksum entry for $ZIP_ASSET_NAME, skipping"
+            fail "Manifest present but no entry found for $ZIP_ASSET_NAME. The release may be corrupted."
         fi
     else
-        warn "Could not download checksums, skipping verification"
+        fail "Failed to download release manifest. Cannot verify integrity."
     fi
 elif $VERIFY; then
-    warn "No checksums available for this release"
+    fail "No manifest available for this release. Cannot verify integrity."
 fi
 
 # ─────────────────────────────────────────────────────────────────────
@@ -231,10 +241,10 @@ fi
 
 if command -v gpg &>/dev/null \
    && [[ -n "${SIGNATURE_URL:-}" ]] \
-   && [[ -f "$CHECKSUMS_FILE" ]]; then
+   && [[ -f "$MANIFEST_FILE" ]]; then
 
     KEY_FILE="$TMPDIR/trusted-key.asc"
-    SIG_FILE="$TMPDIR/checksums.sha256.asc"
+    SIG_FILE="$TMPDIR/manifest.json.asc"
 
     # Write the embedded trusted key to a temp file
     echo "$TRUSTED_KEY" > "$KEY_FILE"
@@ -257,7 +267,7 @@ if command -v gpg &>/dev/null \
         fi
 
         # Verify the signature -- fail-closed
-        if gpg --batch --verify "$SIG_FILE" "$CHECKSUMS_FILE" 2>/dev/null; then
+        if gpg --batch --verify "$SIG_FILE" "$MANIFEST_FILE" 2>/dev/null; then
             ok "GPG signature verified (trusted key: ${TRUSTED_FINGERPRINT:0:16}...)"
         else
             fail "GPG signature verification FAILED. The release may be tampered with."

--- a/repositories/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/java/version/JavaVersionRepository.kt
@@ -36,7 +36,7 @@ class JavaVersionRepository(
 
     companion object {
         val ONLINE_VERSION_CACHE = EasyCache<List<CloudJavaVersion>, Unit>(1.minutes) {
-            val json = getTextOfAPIWithFallback("api-files/java-versions.json")
+            val json = getTextFromGitHub("api-files/java-versions.json")
             gson.fromJsonToList<CloudJavaVersion>(json)
         }
     }

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionRepository.kt
@@ -9,7 +9,7 @@ import dev.redicloud.packets.PacketManager
 import dev.redicloud.repository.cache.CachedDatabaseBucketRepository
 import dev.redicloud.repository.server.version.serverversion.ServerVersion
 import dev.redicloud.utils.SingleCache
-import dev.redicloud.utils.getTextOfAPIWithFallback
+import dev.redicloud.utils.getTextFromGitHub
 import dev.redicloud.utils.gson.fromJsonToList
 import dev.redicloud.utils.gson.gson
 import dev.redicloud.utils.gson.gsonInterfaceFactory
@@ -37,7 +37,7 @@ class CloudServerVersionRepository(
         val LOGGER = LogManager.logger(CloudServerVersionRepository::class)
         val DEFAULT_VERSIONS_CACHE = SingleCache(1.minutes) {
             gsonInterfaceFactory.register(IServerVersion::class, ServerVersion::class)
-            val json = getTextOfAPIWithFallback("api-files/versions.json")
+            val json = getTextFromGitHub("api-files/versions.json")
             gson.fromJsonToList<CloudServerVersion>(json)
         }
     }

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionType.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionType.kt
@@ -21,6 +21,7 @@ class CloudServerVersionType(
     override var connectorDownloadUrl: String?,
     override var connectorFolder: String,
     override var libPattern: String? = null,
+    override var connectorSha256: String? = null,
     override val jvmArguments: MutableList<String> = mutableListOf(),
     override val environmentVariables: MutableMap<String, String> = mutableMapOf(),
     override val programParameters: MutableList<String> = mutableListOf(),
@@ -105,7 +106,8 @@ class CloudServerVersionType(
         if (connectorPluginName != other.connectorPluginName) return false
         if (connectorDownloadUrl != other.connectorDownloadUrl) return false
         if (connectorFolder != other.connectorFolder) return false
-        return libPattern == other.libPattern
+        if (libPattern != other.libPattern) return false
+        return connectorSha256 == other.connectorSha256
     }
 
     override fun hashCode(): Int {
@@ -118,6 +120,7 @@ class CloudServerVersionType(
         result = 31 * result + (connectorDownloadUrl?.hashCode() ?: 0)
         result = 31 * result + connectorFolder.hashCode()
         result = 31 * result + (libPattern?.hashCode() ?: 0)
+        result = 31 * result + (connectorSha256?.hashCode() ?: 0)
         result = 31 * result + jvmArguments.hashCode()
         result = 31 * result + environmentVariables.hashCode()
         result = 31 * result + programParameters.hashCode()
@@ -137,6 +140,7 @@ class CloudServerVersionType(
             connectorDownloadUrl = connectorDownloadUrl,
             connectorFolder = connectorFolder,
             libPattern = libPattern,
+            connectorSha256 = connectorSha256,
             jvmArguments = jvmArguments.toMutableList(),
             environmentVariables = environmentVariables.toMutableMap(),
             programParameters = programParameters.toMutableList(),

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.util.*
 import java.util.logging.Level
 import kotlin.time.Duration.Companion.minutes
@@ -109,7 +110,13 @@ class CloudServerVersionTypeRepository(
 
     override suspend fun downloadConnector(serverVersionType: ICloudServerVersionType, force: Boolean, lock: Boolean) {
         val connectorFile = serverVersionType.getParsedConnectorFile(true)
-        if (connectorFile.exists() && !force) return
+
+        // Local-first: if connector already exists (e.g. from release zip), verify and skip download
+        if (connectorFile.exists() && !force) {
+            verifyConnectorIfPossible(serverVersionType, connectorFile)
+            return
+        }
+
         var canceled = false
         var downloaded = false
         var error = false
@@ -140,16 +147,20 @@ class CloudServerVersionTypeRepository(
             try {
                 check(
                     serverVersionType.getParsedConnectorURL().isValid()
-                ) { "Connector download url of ${serverVersionType.connectorPluginName} is null!" }
+                ) { "Connector download url of ${serverVersionType.connectorPluginName} is not reachable!" }
                 httpClient.get {
                     url(serverVersionType.getParsedConnectorURL().toExternalForm())
-                }.readRawBytes().let {
+                }.readRawBytes().let { bytes ->
                     withContext(Dispatchers.IO) {
                         if (connectorFile.exists()) connectorFile.delete()
                         connectorFile.createNewFile()
-                        connectorFile.writeBytes(it)
+                        connectorFile.writeBytes(bytes)
                     }
                 }
+
+                // Verify integrity after download
+                verifyConnectorIfPossible(serverVersionType, connectorFile)
+
                 LOGGER.log(
                     if (console == null) Level.FINE else Level.INFO,
                     "Successfully downloaded connector for ${toConsoleValue(serverVersionType.name)}!"
@@ -159,6 +170,43 @@ class CloudServerVersionTypeRepository(
                 error = true
             } finally {
                 downloaded = true
+            }
+        }
+    }
+
+    /**
+     * Verifies a connector file's SHA-256 hash if a hash is available.
+     *
+     * For custom connectors, the hash comes from [ICloudServerVersionType.connectorSha256].
+     * For built-in connectors, the hash comes from the release manifest (looked up by filename).
+     *
+     * @throws IllegalStateException if a hash is available but does not match.
+     */
+    private fun verifyConnectorIfPossible(
+        serverVersionType: ICloudServerVersionType,
+        connectorFile: File
+    ) {
+        // 1. Check custom sha256 field (for community connectors)
+        val customHash = serverVersionType.connectorSha256
+        if (customHash != null) {
+            check(verifyFileHash(connectorFile, customHash)) {
+                "SHA-256 mismatch for connector ${connectorFile.name}: " +
+                    "expected $customHash, got ${sha256(connectorFile)}"
+            }
+            LOGGER.info("SHA-256 verified for connector ${toConsoleValue(connectorFile.name, false)}")
+            return
+        }
+
+        // 2. Check release manifest (for built-in connectors)
+        val manifest = ManifestHolder.manifest
+        if (manifest != null) {
+            val expectedHash = manifest.findHashByFilename(connectorFile.name)
+            if (expectedHash != null) {
+                check(verifyFileHash(connectorFile, expectedHash)) {
+                    "SHA-256 mismatch for connector ${connectorFile.name}: " +
+                        "expected $expectedHash, got ${sha256(connectorFile)}"
+                }
+                LOGGER.info("SHA-256 verified for connector ${toConsoleValue(connectorFile.name, false)} (manifest)")
             }
         }
     }

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/CloudServerVersionTypeRepository.kt
@@ -55,7 +55,7 @@ class CloudServerVersionTypeRepository(
         val LOGGER = LogManager.logger(CloudServerVersionTypeRepository::class)
         val DEFAULT_TYPES_CACHE = SingleCache(1.minutes) {
             gsonInterfaceFactory.register(IServerVersion::class, ServerVersion::class)
-            val json = getTextOfAPIWithFallback("api-files/server-version-types.json")
+            val json = getTextFromGitHub("api-files/server-version-types.json")
             val list: MutableList<CloudServerVersionType> = gson.fromJsonToList<CloudServerVersionType>(
                 json
             ).toMutableList()

--- a/repositories/src/main/kotlin/dev/redicloud/repository/server/version/serverversion/VersionRepository.kt
+++ b/repositories/src/main/kotlin/dev/redicloud/repository/server/version/serverversion/VersionRepository.kt
@@ -2,7 +2,7 @@ package dev.redicloud.repository.server.version.serverversion
 
 import dev.redicloud.api.version.IServerVersion
 import dev.redicloud.api.version.IVersionRepository
-import dev.redicloud.utils.getTextOfAPIWithFallback
+import dev.redicloud.utils.getTextFromGitHub
 import dev.redicloud.utils.gson.fromJsonToList
 import dev.redicloud.utils.gson.gson
 
@@ -17,7 +17,7 @@ object VersionRepository : IVersionRepository {
 
     override suspend fun loadOnlineVersions() {
         cachedVersions.clear()
-        val json = getTextOfAPIWithFallback("api-files/server-versions.json")
+        val json = getTextFromGitHub("api-files/server-versions.json")
         val list = gson.fromJsonToList<ServerVersion>(json).toMutableList()
         if (list.none { it.unknown }) {
             list.add(ServerVersion("unknown", -1, emptyArray()))

--- a/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/FileCopier.kt
+++ b/server-factories/node-server-factory/src/main/kotlin/dev/redicloud/server/factory/FileCopier.kt
@@ -83,9 +83,9 @@ class FileCopier(
                         return
                     }
                 } catch (e: Exception) {
+                    val url = snapshot.versionType.connectorDownloadUrl ?: "n/a"
                     logger.warning(
-                        "Failed to download connector for ${snapshot.versionType.name} " +
-                            "from ${snapshot.versionType.getParsedConnectorURL().toExternalForm()}",
+                        "Failed to download connector for ${snapshot.versionType.name} from $url",
                         e
                     )
                     logger.warning("The server will not connect to the cloud cluster!")

--- a/updater/src/main/kotlin/dev/redicloud/updater/ManifestInfo.kt
+++ b/updater/src/main/kotlin/dev/redicloud/updater/ManifestInfo.kt
@@ -1,0 +1,66 @@
+package dev.redicloud.updater
+
+/**
+ * Represents a signed release manifest (`manifest.json`).
+ *
+ * The manifest contains version metadata and SHA-256 checksums for every artifact
+ * in a release (zip, connectors, node-service JAR, modules). It replaces the flat
+ * `checksums.sha256` file and is GPG-signed (`manifest.json.asc`).
+ *
+ * ## Verification chain
+ * ```
+ * manifest.json.asc  --GPG verify-->  manifest.json  --SHA-256-->  each artifact
+ * ```
+ */
+data class ManifestInfo(
+    /** Base semver version, e.g. `2.4.0`. */
+    val version: String,
+    /** Full version including channel, build, and git SHA, e.g. `2.4.0-beta.42+abc1234`. */
+    val fullVersion: String,
+    /** Release channel: `stable`, `beta`, `dev`. */
+    val channel: String,
+    /** ISO 8601 UTC timestamp of the release build. */
+    val timestamp: String,
+    /** Minimum required Java version (e.g. `21`). */
+    val minJavaVersion: Int,
+    /** Map of relative artifact path to its metadata. */
+    val artifacts: Map<String, ArtifactInfo>
+) {
+
+    /**
+     * Looks up the SHA-256 hash for an artifact by its filename (last path segment).
+     *
+     * This searches all artifact keys and matches by the filename portion,
+     * so `redicloud-bukkit-connector-2.4.0.jar` matches the key
+     * `connectors/redicloud-bukkit-connector-2.4.0.jar`.
+     *
+     * @return the lowercase hex SHA-256 hash, or `null` if no matching artifact exists.
+     */
+    fun findHashByFilename(filename: String): String? =
+        artifacts.entries
+            .firstOrNull { (key, _) ->
+                key == filename || key.substringAfterLast('/') == filename
+            }
+            ?.value?.sha256
+
+    /**
+     * Looks up the [ArtifactInfo] for an artifact by its exact key or filename.
+     */
+    fun findArtifact(filename: String): ArtifactInfo? =
+        artifacts[filename]
+            ?: artifacts.entries
+                .firstOrNull { (key, _) -> key.substringAfterLast('/') == filename }
+                ?.value
+}
+
+/**
+ * Metadata for a single artifact within the release manifest.
+ */
+data class ArtifactInfo(
+    /** Lowercase hex SHA-256 hash of the artifact. */
+    val sha256: String,
+    /** File size in bytes. */
+    val size: Long,
+    /** Artifact type: `distribution`, `connector`, `service`, `module`. */
+    val type: String
+)

--- a/updater/src/main/kotlin/dev/redicloud/updater/ReleaseInfo.kt
+++ b/updater/src/main/kotlin/dev/redicloud/updater/ReleaseInfo.kt
@@ -11,8 +11,8 @@ data class ReleaseInfo(
     val version: CloudVersion,
     val tagName: String,
     val zipUrl: String?,
-    val checksumsUrl: String?,
-    val signatureUrl: String?
+    val manifestUrl: String?,
+    val manifestSignatureUrl: String?
 ) {
     val channel: VersionChannel
         get() = version.channel

--- a/updater/src/main/kotlin/dev/redicloud/updater/Updater.kt
+++ b/updater/src/main/kotlin/dev/redicloud/updater/Updater.kt
@@ -97,6 +97,13 @@ object Updater {
     // Download & verify
     // ------------------------------------------------------------------
 
+    /**
+     * The manifest for the currently running release, loaded lazily on first use.
+     * Other modules (e.g. connector verification) can query this to look up artifact hashes.
+     */
+    var cachedManifest: ManifestInfo? = null
+        private set
+
     /** Downloads a release zip into the `versions/` directory. */
     suspend fun download(release: ReleaseInfo): File {
         val zipUrl = release.zipUrl
@@ -110,60 +117,94 @@ object Updater {
         target.writeBytes(response.readRawBytes())
 
         // Verify integrity -- fail-closed: if assets exist but verification fails, abort.
-        val checksumsBytes = release.checksumsUrl?.let { downloadBytes(it) }
-        if (checksumsBytes != null) {
-            verifyChecksum(target, checksumsBytes)
-            if (release.signatureUrl != null) {
-                verifyGpgSignature(checksumsBytes, release.signatureUrl)
+        val manifestBytes = release.manifestUrl?.let { downloadBytes(it) }
+        if (manifestBytes != null) {
+            if (release.manifestSignatureUrl != null) {
+                verifyGpgSignature(manifestBytes, release.manifestSignatureUrl)
             } else {
                 LogManager.rootLogger().warning("No GPG signature available for this release")
             }
+            val manifest = parseManifest(manifestBytes)
+            cachedManifest = manifest
+            verifyArtifactHash(target, manifest)
         } else {
-            LogManager.rootLogger().warning("No checksums available for this release, integrity not verified")
+            LogManager.rootLogger().warning("No manifest available for this release, integrity not verified")
         }
 
         return target
     }
 
     /**
-     * Verifies the zip file against the downloaded checksums.
+     * Loads and caches the manifest for the current release (by tag).
+     * Used by connector verification to look up expected hashes.
      *
-     * @throws IllegalStateException if the checksum does not match.
+     * @return the manifest, or `null` if unavailable.
      */
-    private fun verifyChecksum(zipFile: File, checksumsBytes: ByteArray) {
-        val checksumLines = checksumsBytes.decodeToString().lines()
-        val expectedHash = checksumLines
-            .firstOrNull { it.contains(zipFile.name) }
-            ?.split("\\s+".toRegex())
-            ?.firstOrNull()
-
-        checkNotNull(expectedHash) {
-            "No checksum entry found for ${zipFile.name} in checksums file"
+    suspend fun loadManifestForCurrentRelease(): ManifestInfo? {
+        if (cachedManifest != null) return cachedManifest
+        val current = CLOUD_VERSION_PARSED ?: return null
+        val release = getReleasesByChannel(current.channel)
+            .firstOrNull { it.version == current }
+            ?: return null
+        val manifestBytes = release.manifestUrl?.let { downloadBytes(it) } ?: return null
+        if (release.manifestSignatureUrl != null) {
+            verifyGpgSignature(manifestBytes, release.manifestSignatureUrl)
         }
+        val manifest = parseManifest(manifestBytes)
+        cachedManifest = manifest
+        return manifest
+    }
 
-        val actualHash = sha256(zipFile)
-        check(actualHash.equals(expectedHash, ignoreCase = true)) {
-            "Checksum mismatch for ${zipFile.name}: expected $expectedHash, got $actualHash"
-        }
-        LogManager.rootLogger().info("SHA256 checksum verified for ${zipFile.name}")
+    /** Parses manifest JSON bytes into a [ManifestInfo]. */
+    private fun parseManifest(manifestBytes: ByteArray): ManifestInfo {
+        val json = manifestBytes.decodeToString()
+        return gson.fromJson(json, ManifestInfo::class.java)
+            ?: error("Failed to parse manifest.json")
     }
 
     /**
-     * Verifies the GPG signature of the checksums file using the embedded trusted public key.
+     * Verifies an artifact file against the manifest.
+     *
+     * @throws IllegalStateException if the hash does not match.
+     */
+    private fun verifyArtifactHash(file: File, manifest: ManifestInfo) {
+        val expectedHash = manifest.findHashByFilename(file.name)
+        checkNotNull(expectedHash) {
+            "No manifest entry found for ${file.name}"
+        }
+        val actualHash = sha256(file)
+        check(actualHash.equals(expectedHash, ignoreCase = true)) {
+            "Checksum mismatch for ${file.name}: expected $expectedHash, got $actualHash"
+        }
+        LogManager.rootLogger().info("SHA-256 verified for ${file.name}")
+    }
+
+    /**
+     * Verifies a file's SHA-256 against an expected hash string.
+     *
+     * @return `true` if the hash matches, `false` otherwise.
+     */
+    fun verifyFileHash(file: File, expectedSha256: String): Boolean {
+        val actualHash = sha256(file)
+        return actualHash.equals(expectedSha256, ignoreCase = true)
+    }
+
+    /**
+     * Verifies the GPG signature of the manifest using the embedded trusted public key.
      *
      * Fail-closed: if the signature exists but is invalid or the download fails, the update is aborted.
      *
      * @throws IllegalStateException if the signature is invalid or cannot be verified.
      */
     private suspend fun verifyGpgSignature(
-        checksumsBytes: ByteArray,
+        manifestBytes: ByteArray,
         signatureUrl: String
     ) {
         val signatureBytes = downloadBytes(signatureUrl)
             ?: error("Failed to download GPG signature from $signatureUrl")
 
         val verified = GpgVerifier.verify(
-            data = checksumsBytes,
+            data = manifestBytes,
             signature = signatureBytes
         )
         check(verified) { "GPG signature verification failed: signature is invalid or key is not trusted" }
@@ -276,8 +317,8 @@ object Updater {
             version = version,
             tagName = tagName,
             zipUrl = assets.firstOrNull { it.name.endsWith(".zip") }?.downloadUrl,
-            checksumsUrl = assets.firstOrNull { it.name == "checksums.sha256" }?.downloadUrl,
-            signatureUrl = assets.firstOrNull { it.name == "checksums.sha256.asc" }?.downloadUrl
+            manifestUrl = assets.firstOrNull { it.name == "manifest.json" }?.downloadUrl,
+            manifestSignatureUrl = assets.firstOrNull { it.name == "manifest.json.asc" }?.downloadUrl
         )
     }
 }

--- a/updater/src/main/kotlin/dev/redicloud/updater/Updater.kt
+++ b/updater/src/main/kotlin/dev/redicloud/updater/Updater.kt
@@ -13,7 +13,6 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import java.io.File
-import java.security.MessageDigest
 import java.util.*
 import java.util.jar.JarFile
 
@@ -21,7 +20,6 @@ import java.util.jar.JarFile
 object Updater {
 
     private const val GITHUB_API = "https://api.github.com/repos/RediCloud/cloud-v2/releases"
-    private const val BUFFER_SIZE = 8192
 
     private val updateInfoFile = File(".update-info")
 
@@ -99,10 +97,13 @@ object Updater {
 
     /**
      * The manifest for the currently running release, loaded lazily on first use.
-     * Other modules (e.g. connector verification) can query this to look up artifact hashes.
+     * Also published to [ManifestHolder] so other modules can query artifact hashes.
      */
     var cachedManifest: ManifestInfo? = null
-        private set
+        private set(value) {
+            field = value
+            ManifestHolder.manifest = value
+        }
 
     /** Downloads a release zip into the `versions/` directory. */
     suspend fun download(release: ReleaseInfo): File {
@@ -177,16 +178,6 @@ object Updater {
             "Checksum mismatch for ${file.name}: expected $expectedHash, got $actualHash"
         }
         LogManager.rootLogger().info("SHA-256 verified for ${file.name}")
-    }
-
-    /**
-     * Verifies a file's SHA-256 against an expected hash string.
-     *
-     * @return `true` if the hash matches, `false` otherwise.
-     */
-    fun verifyFileHash(file: File, expectedSha256: String): Boolean {
-        val actualHash = sha256(file)
-        return actualHash.equals(expectedSha256, ignoreCase = true)
     }
 
     /**
@@ -295,18 +286,6 @@ object Updater {
 
     private fun mainFolderJars(): List<File> =
         File(".").listFiles()?.filter { it.extension == "jar" } ?: emptyList()
-
-    private fun sha256(file: File): String {
-        val digest = MessageDigest.getInstance("SHA-256")
-        file.inputStream().use { input ->
-            val buffer = ByteArray(BUFFER_SIZE)
-            var read: Int
-            while (input.read(buffer).also { read = it } != -1) {
-                digest.update(buffer, 0, read)
-            }
-        }
-        return digest.digest().joinToString("") { "%02x".format(it) }
-    }
 
     /** Converts a GitHub release to our domain model, or `null` if the tag is unparseable. */
     private fun GitHubRelease.toReleaseInfo(): ReleaseInfo? {

--- a/utils/src/main/kotlin/dev/redicloud/utils/GitUtils.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/GitUtils.kt
@@ -12,5 +12,15 @@ fun getGithubUser(): String =
 fun getGithubCommitHash(): String =
     System.getProperty("redicloud.git.commit", "HEAD")
 
-fun getRawUserContentUrl(): String =
-    "https://raw.githubusercontent.com/${getGithubUser()}/${getGithubRepository()}/${getGithubBranch()}"
+/**
+ * Returns the GitHub raw content base URL, pinned to the current git commit hash when available.
+ *
+ * This ensures that fetched api-files (server-version-types.json, etc.) match the running binary
+ * exactly, rather than potentially drifting when the branch moves forward.
+ *
+ * Falls back to the branch name when the commit hash is unavailable (e.g. local dev builds).
+ */
+fun getRawUserContentUrl(): String {
+    val ref = GIT.takeIf { it != "unknown" } ?: getGithubBranch()
+    return "https://raw.githubusercontent.com/${getGithubUser()}/${getGithubRepository()}/$ref"
+}

--- a/utils/src/main/kotlin/dev/redicloud/utils/HashUtils.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/HashUtils.kt
@@ -27,7 +27,7 @@ fun sha256(file: File): String {
  *
  * @return `true` if the hash matches (case-insensitive), `false` otherwise.
  */
-fun sha256(file: File, expectedSha256: String): Boolean {
+fun verifyFileHash(file: File, expectedSha256: String): Boolean {
     val actualHash = sha256(file)
     return actualHash.equals(expectedSha256, ignoreCase = true)
 }

--- a/utils/src/main/kotlin/dev/redicloud/utils/HashUtils.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/HashUtils.kt
@@ -1,0 +1,33 @@
+package dev.redicloud.utils
+
+import java.io.File
+import java.security.MessageDigest
+
+private const val HASH_BUFFER_SIZE = 8192
+
+/**
+ * Computes the SHA-256 hash of a file.
+ *
+ * @return lowercase hex-encoded SHA-256 hash.
+ */
+fun sha256(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+        val buffer = ByteArray(HASH_BUFFER_SIZE)
+        var read: Int
+        while (input.read(buffer).also { read = it } != -1) {
+            digest.update(buffer, 0, read)
+        }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
+}
+
+/**
+ * Verifies a file's SHA-256 against an expected hash string.
+ *
+ * @return `true` if the hash matches (case-insensitive), `false` otherwise.
+ */
+fun sha256(file: File, expectedSha256: String): Boolean {
+    val actualHash = sha256(file)
+    return actualHash.equals(expectedSha256, ignoreCase = true)
+}

--- a/utils/src/main/kotlin/dev/redicloud/utils/ManifestHolder.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/ManifestHolder.kt
@@ -1,0 +1,17 @@
+package dev.redicloud.utils
+
+/**
+ * Global holder for the current release manifest.
+ *
+ * The manifest is loaded and cached by the updater module on startup,
+ * and can be queried by any module (e.g. repositories) to verify artifact integrity.
+ */
+object ManifestHolder {
+
+    /**
+     * The manifest for the currently running release.
+     * Set by the updater on startup; `null` if not yet loaded or unavailable.
+     */
+    @Volatile
+    var manifest: ManifestInfo? = null
+}

--- a/utils/src/main/kotlin/dev/redicloud/utils/ManifestInfo.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/ManifestInfo.kt
@@ -1,4 +1,4 @@
-package dev.redicloud.updater
+package dev.redicloud.utils
 
 /**
  * Represents a signed release manifest (`manifest.json`).

--- a/utils/src/main/kotlin/dev/redicloud/utils/RestAPIUtils.kt
+++ b/utils/src/main/kotlin/dev/redicloud/utils/RestAPIUtils.kt
@@ -24,4 +24,8 @@ suspend fun getTextFromGitHub(path: String): String {
  * Previously tried api.redicloud.dev first with a GitHub fallback.
  * Now goes directly to GitHub raw content.
  */
+@Deprecated(
+    message = "Use getTextFromGitHub() directly",
+    replaceWith = ReplaceWith("getTextFromGitHub(path)")
+)
 suspend fun getTextOfAPIWithFallback(path: String): String = getTextFromGitHub(path)


### PR DESCRIPTION
Replaces the checksums.sha256 integrity file with a structured, GPG-signed manifest.json and migrates all built-in connector downloads from api.redicloud.dev to GitHub Release assets with SHA-256 verification.


