### PR TITLE
Unified Upgrade Command & Migration System

### DIFF
--- a/docs/commands/version-updater.md
+++ b/docs/commands/version-updater.md
@@ -8,29 +8,43 @@ To display the current version information, the following command can be used:
 
 This information is helpful in a bug report!
 
-
-
-## Update your cloud (to latest)
+## Upgrade your cloud (to latest)
 
 1. Use `version checkupdate` to check if there is a new version
-2. Download the version: `version download`
-3. Switch to the version: `version switch`
-4. Restart your cloud
+2. Upgrade: `version upgrade`
+3. Shut down the entire cluster
+4. Restart all nodes — migrations will run automatically on first startup
+
+The `version upgrade` command will upgrade **all connected nodes** in the cluster automatically.
+A live status overview shows the progress per node during the upgrade.
 
 {% hint style="info" %}
 The `versions/` folder should be deleted regularly
 {% endhint %}
 
-##
+## Upgrade your cloud (to specific version)
 
-## Update your cloud (to specific version)
-
-1. You should also know the branch of the version first (show all branches: `version branches`)
-2. Then you should check whether the build for this branch exists (show all builds: `version builds <branch>`)
-3. Download the version: `version download <branch> <build>`
-4. Switch to the version: `version switch <branch> <build<`
-5. Restart your cloud
+1. Check available channels: `version channels`
+2. Check available releases for a channel: `version releases <channel>`
+3. Upgrade: `version upgrade <channel> <version>`
+4. Shut down the entire cluster
+5. Restart all nodes — migrations will run automatically on first startup
 
 {% hint style="info" %}
 The `versions/` folder should be deleted regularly
 {% endhint %}
+
+## Migrations
+
+When the cloud version changes, database and local file migrations run automatically on startup:
+
+- **Database migrations** run once per cluster (protected by a distributed lock). Other nodes wait until the migration is complete.
+- **Local migrations** run on every node independently.
+
+The schema version is stored in Redis at `cloud:schema-version`.
+
+## Auto-upgrade on version mismatch
+
+If a node starts with a JAR version that is older than the cluster's schema version,
+it will automatically download and install the correct version, then shut down.
+On the next restart, the node will start with the correct version and run any pending migrations.

--- a/migrations/build.gradle.kts
+++ b/migrations/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("redicloud-conventions")
+}
+
+group = "dev.redicloud"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly(project(":apis:base-api"))
+    compileOnly(project(":database"))
+    compileOnly(project(":utils"))
+    compileOnly(project(":logging"))
+
+    dependency(libs.kotlinx.coroutines)
+}

--- a/migrations/src/main/kotlin/dev/redicloud/migration/Migration.kt
+++ b/migrations/src/main/kotlin/dev/redicloud/migration/Migration.kt
@@ -1,0 +1,26 @@
+package dev.redicloud.migration
+
+import dev.redicloud.utils.version.CloudVersion
+
+/**
+ * A single migration step that upgrades or downgrades data/files between cloud versions.
+ *
+ * Implementations must be registered in [MigrationRegistry].
+ */
+interface Migration {
+
+    /** The version this migration upgrades **to**. */
+    val version: CloudVersion
+
+    /** Whether this migration operates on shared Redis data or local files. */
+    val type: MigrationType
+
+    /** Human-readable description of what this migration does. */
+    val description: String
+
+    /** Run the upgrade migration. */
+    suspend fun up(context: MigrationContext)
+
+    /** Run the downgrade migration (rollback). */
+    suspend fun down(context: MigrationContext)
+}

--- a/migrations/src/main/kotlin/dev/redicloud/migration/MigrationContext.kt
+++ b/migrations/src/main/kotlin/dev/redicloud/migration/MigrationContext.kt
@@ -1,0 +1,12 @@
+package dev.redicloud.migration
+
+import dev.redicloud.api.database.IDatabaseConnection
+import java.io.File
+
+/**
+ * Context passed to each migration, providing access to the database and the local working directory.
+ */
+data class MigrationContext(
+    val databaseConnection: IDatabaseConnection,
+    val workingDirectory: File
+)

--- a/migrations/src/main/kotlin/dev/redicloud/migration/MigrationRegistry.kt
+++ b/migrations/src/main/kotlin/dev/redicloud/migration/MigrationRegistry.kt
@@ -1,0 +1,54 @@
+package dev.redicloud.migration
+
+import dev.redicloud.utils.version.CloudVersion
+
+/**
+ * Central registry for all known migrations.
+ *
+ * Migrations are registered explicitly at startup before the [MigrationRunner] executes.
+ */
+object MigrationRegistry {
+
+    private val migrations = mutableListOf<Migration>()
+
+    /** Register a migration. */
+    fun register(migration: Migration) {
+        migrations.add(migration)
+    }
+
+    /** Register multiple migrations at once. */
+    fun registerAll(vararg migrations: Migration) {
+        migrations.forEach { register(it) }
+    }
+
+    /**
+     * Returns the migrations that need to run between [from] and [to], ordered correctly.
+     *
+     * - **Upgrade** (from < to): returns migrations where `version` is in `(from, to]`, ascending by version.
+     * - **Downgrade** (from > to): returns migrations where `version` is in `(to, from]`, descending by version.
+     * - **Same version**: returns an empty list.
+     */
+    fun getMigrationsBetween(from: CloudVersion, to: CloudVersion): List<Migration> {
+        if (from == to) return emptyList()
+
+        return if (from < to) {
+            // Upgrade: run migrations for versions after 'from' up to and including 'to'
+            migrations
+                .filter { it.version > from && it.version <= to }
+                .sortedBy { it.version }
+        } else {
+            // Downgrade: run migrations for versions after 'to' up to and including 'from'
+            migrations
+                .filter { it.version > to && it.version <= from }
+                .sortedByDescending { it.version }
+        }
+    }
+
+    /** Returns all registered migrations. */
+    fun all(): List<Migration> = migrations.toList()
+
+    /** Clears all registered migrations. Mainly useful for testing. */
+    fun clear() {
+        migrations.clear()
+    }
+}

--- a/migrations/src/main/kotlin/dev/redicloud/migration/MigrationResult.kt
+++ b/migrations/src/main/kotlin/dev/redicloud/migration/MigrationResult.kt
@@ -1,0 +1,18 @@
+package dev.redicloud.migration
+
+import dev.redicloud.utils.version.CloudVersion
+
+/**
+ * Result of [MigrationRunner.run], indicating what action the caller should take.
+ */
+sealed class MigrationResult {
+
+    /** Migrations completed successfully (or none were needed). Startup can continue. */
+    data object Success : MigrationResult()
+
+    /**
+     * The cluster schema version is ahead of this node's JAR version.
+     * The caller must upgrade the node to [targetVersion] and restart.
+     */
+    data class UpgradeRequired(val targetVersion: CloudVersion) : MigrationResult()
+}

--- a/migrations/src/main/kotlin/dev/redicloud/migration/MigrationRunner.kt
+++ b/migrations/src/main/kotlin/dev/redicloud/migration/MigrationRunner.kt
@@ -38,16 +38,32 @@ class MigrationRunner(
     }
 
     /**
-     * Runs all pending migrations.
+     * Runs all pending migrations, or signals that the node needs an upgrade first.
+     *
+     * Call this after the database connection is established but **before** the node registers as connected.
      *
      * @param currentVersion the version of the running JAR (from build properties)
-     * @throws IllegalStateException if migrations fail or the wait-state times out
+     * @return [MigrationResult.Success] if migrations ran (or none were needed),
+     *         [MigrationResult.UpgradeRequired] if the node JAR is behind the cluster schema version.
+     * @throws IllegalStateException if a migration fails or the wait-state times out
      */
-    suspend fun run(currentVersion: CloudVersion) {
-        val context = MigrationContext(databaseConnection, workingDirectory)
+    suspend fun run(currentVersion: CloudVersion): MigrationResult {
+        val schemaVersion = getSchemaVersion()
 
+        // If the cluster schema is ahead of our JAR, we need to upgrade first
+        if (schemaVersion != null && schemaVersion > currentVersion) {
+            LOGGER.info(
+                "Cluster schema version (${schemaVersion.display}) is ahead of this node (${currentVersion.display}). " +
+                    "Upgrade required."
+            )
+            return MigrationResult.UpgradeRequired(schemaVersion)
+        }
+
+        val context = MigrationContext(databaseConnection, workingDirectory)
         runDatabaseMigrations(currentVersion, context)
         runLocalMigrations(currentVersion, context)
+
+        return MigrationResult.Success
     }
 
     // ------------------------------------------------------------------

--- a/migrations/src/main/kotlin/dev/redicloud/migration/MigrationRunner.kt
+++ b/migrations/src/main/kotlin/dev/redicloud/migration/MigrationRunner.kt
@@ -1,0 +1,209 @@
+package dev.redicloud.migration
+
+import dev.redicloud.api.database.IDatabaseConnection
+import dev.redicloud.logging.LogManager
+import dev.redicloud.utils.version.CloudVersion
+import kotlinx.coroutines.delay
+import java.io.File
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Executes pending migrations on startup.
+ *
+ * - [MigrationType.DATABASE] migrations run **once** across the cluster, protected by a distributed lock.
+ * - [MigrationType.LOCAL] migrations run **on every node** independently.
+ *
+ * Must be called after the database connection is established but before the node registers as connected.
+ */
+class MigrationRunner(
+    private val databaseConnection: IDatabaseConnection,
+    private val workingDirectory: File = File("."),
+    private val lockTimeout: Duration = LOCK_TIMEOUT,
+    private val waitTimeout: Duration = WAIT_TIMEOUT,
+    private val waitPollInterval: Duration = WAIT_POLL_INTERVAL
+) {
+
+    companion object {
+        private val LOGGER = LogManager.logger(MigrationRunner::class)
+
+        private const val SCHEMA_VERSION_KEY = "cloud:schema-version"
+        private const val MIGRATION_LOCK_KEY = "cloud:migration-lock"
+        private const val LOCAL_SCHEMA_VERSION_FILE = ".local-schema-version"
+
+        private val LOCK_TIMEOUT = 5.minutes
+        private val WAIT_TIMEOUT = 10.minutes
+        private val WAIT_POLL_INTERVAL = 2.seconds
+    }
+
+    /**
+     * Runs all pending migrations.
+     *
+     * @param currentVersion the version of the running JAR (from build properties)
+     * @throws IllegalStateException if migrations fail or the wait-state times out
+     */
+    suspend fun run(currentVersion: CloudVersion) {
+        val context = MigrationContext(databaseConnection, workingDirectory)
+
+        runDatabaseMigrations(currentVersion, context)
+        runLocalMigrations(currentVersion, context)
+    }
+
+    // ------------------------------------------------------------------
+    // Database Migrations (once per cluster, with distributed lock)
+    // ------------------------------------------------------------------
+
+    private suspend fun runDatabaseMigrations(currentVersion: CloudVersion, context: MigrationContext) {
+        val storedVersion = getSchemaVersion()
+
+        if (storedVersion == null) {
+            // First run ever -- set schema version to current, no migrations needed
+            LOGGER.info("No schema version found. Initializing to ${currentVersion.display}")
+            setSchemaVersion(currentVersion)
+            return
+        }
+
+        if (storedVersion == currentVersion) {
+            LOGGER.info("Database schema is up to date (${currentVersion.display})")
+            return
+        }
+
+        val isUpgrade = storedVersion < currentVersion
+        val allMigrations = MigrationRegistry.getMigrationsBetween(storedVersion, currentVersion)
+        val dbMigrations = allMigrations.filter { it.type == MigrationType.DATABASE }
+
+        if (dbMigrations.isEmpty()) {
+            LOGGER.info("No database migrations needed ($storedVersion -> $currentVersion)")
+            setSchemaVersion(currentVersion)
+            return
+        }
+
+        val direction = if (isUpgrade) "Upgrading" else "Downgrading"
+        LOGGER.info("$direction database: $storedVersion -> $currentVersion (${dbMigrations.size} migrations)")
+
+        val lock = databaseConnection.getLock(MIGRATION_LOCK_KEY)
+
+        // Try to acquire the lock
+        if (lock.isLocked() && !lock.isHeldByCurrentThread()) {
+            LOGGER.info("Another node is running database migrations. Waiting...")
+            waitForMigrationComplete(currentVersion)
+            return
+        }
+
+        lock.lock(lockTimeout)
+        try {
+            // Re-check schema version -- another node may have migrated while we waited for the lock
+            val recheckVersion = getSchemaVersion()
+            if (recheckVersion == currentVersion) {
+                LOGGER.info("Database schema was already migrated by another node")
+                return
+            }
+
+            for (migration in dbMigrations) {
+                LOGGER.info("Running database migration: ${migration.description} (-> ${migration.version})")
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    if (isUpgrade) migration.up(context) else migration.down(context)
+                } catch (e: Exception) {
+                    LOGGER.severe("Database migration failed: ${migration.description}", e)
+                    throw IllegalStateException(
+                        "Database migration failed: ${migration.description}. " +
+                            "The cluster may be in a partially migrated state. Manual intervention required.",
+                        e
+                    )
+                }
+            }
+
+            setSchemaVersion(currentVersion)
+            LOGGER.info("Database migrations complete. Schema version: $currentVersion")
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    /**
+     * Wait-state: polls until the schema version matches or timeout is reached.
+     */
+    private suspend fun waitForMigrationComplete(expectedVersion: CloudVersion) {
+        val deadline = System.currentTimeMillis() + waitTimeout.inWholeMilliseconds
+        while (System.currentTimeMillis() < deadline) {
+            delay(waitPollInterval)
+            val currentSchema = getSchemaVersion()
+            if (currentSchema == expectedVersion) {
+                LOGGER.info("Database migration completed by another node. Continuing startup.")
+                return
+            }
+        }
+        throw IllegalStateException(
+            "Timed out waiting for database migration to complete " +
+                "(expected schema version: $expectedVersion). " +
+                "Check if the migrating node is still running."
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Local Migrations (per node, file/folder changes)
+    // ------------------------------------------------------------------
+
+    private suspend fun runLocalMigrations(currentVersion: CloudVersion, context: MigrationContext) {
+        val localVersionFile = File(workingDirectory, LOCAL_SCHEMA_VERSION_FILE)
+        val storedLocal = if (localVersionFile.exists()) {
+            CloudVersion.parseOrNull(localVersionFile.readText().trim())
+        } else {
+            null
+        }
+
+        if (storedLocal == null) {
+            // First run -- initialize
+            localVersionFile.writeText(currentVersion.display)
+            return
+        }
+
+        if (storedLocal == currentVersion) return
+
+        val isUpgrade = storedLocal < currentVersion
+        val allMigrations = MigrationRegistry.getMigrationsBetween(storedLocal, currentVersion)
+        val localMigrations = allMigrations.filter { it.type == MigrationType.LOCAL }
+
+        if (localMigrations.isEmpty()) {
+            localVersionFile.writeText(currentVersion.display)
+            return
+        }
+
+        val direction = if (isUpgrade) "Upgrading" else "Downgrading"
+        LOGGER.info("$direction local files: $storedLocal -> $currentVersion (${localMigrations.size} migrations)")
+
+        for (migration in localMigrations) {
+            LOGGER.info("Running local migration: ${migration.description} (-> ${migration.version})")
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                if (isUpgrade) migration.up(context) else migration.down(context)
+            } catch (e: Exception) {
+                LOGGER.severe("Local migration failed: ${migration.description}", e)
+                throw IllegalStateException(
+                    "Local migration failed: ${migration.description}. Manual intervention required.",
+                    e
+                )
+            }
+        }
+
+        localVersionFile.writeText(currentVersion.display)
+        LOGGER.info("Local migrations complete.")
+    }
+
+    // ------------------------------------------------------------------
+    // Schema version helpers
+    // ------------------------------------------------------------------
+
+    private suspend fun getSchemaVersion(): CloudVersion? {
+        val bucket = databaseConnection.getBucket<String>(SCHEMA_VERSION_KEY)
+        val raw = bucket.get() ?: return null
+        return CloudVersion.parseOrNull(raw)
+    }
+
+    private suspend fun setSchemaVersion(version: CloudVersion) {
+        val bucket = databaseConnection.getBucket<String>(SCHEMA_VERSION_KEY)
+        bucket.set(version.display)
+    }
+}

--- a/migrations/src/main/kotlin/dev/redicloud/migration/MigrationType.kt
+++ b/migrations/src/main/kotlin/dev/redicloud/migration/MigrationType.kt
@@ -1,0 +1,19 @@
+package dev.redicloud.migration
+
+/**
+ * Defines where a migration operates.
+ */
+enum class MigrationType {
+
+    /**
+     * Modifies shared Redis data (keys, values, structures).
+     * Executed **once** across the entire cluster, protected by a distributed lock.
+     */
+    DATABASE,
+
+    /**
+     * Modifies local file/folder structure on each node.
+     * Executed **on every node** independently.
+     */
+    LOCAL
+}

--- a/services/node-service/build.gradle.kts
+++ b/services/node-service/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     shade(libs.libloader.bootstrap)
     shade(project(":modules:module-handler"))
     shade(project(":updater"))
+    shade(project(":migrations"))
     shade(libs.logback.classic)
     shade(libs.logback.core)
     dependency(libs.adventure.api)

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
@@ -37,7 +37,11 @@ import dev.redicloud.service.node.tasks.player.PlayerProxyConnectionStateTask
 import dev.redicloud.service.node.packets.upgrade.ClusterUpgradePacket
 import dev.redicloud.service.node.packets.upgrade.ClusterUpgradeResponsePacket
 import dev.redicloud.service.node.tasks.service.CloudInvalidServerUnregisterTask
+import dev.redicloud.migration.MigrationResult
+import dev.redicloud.migration.MigrationRunner
 import dev.redicloud.updater.Updater
+import dev.redicloud.utils.CLOUD_VERSION_PARSED
+import dev.redicloud.utils.version.CloudVersion
 import kotlinx.coroutines.runBlocking
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -85,6 +89,12 @@ class NodeService(
         initShutdownHook()
 
         Updater.check()
+
+        // Run migrations (or auto-upgrade if this node is behind the cluster)
+        val currentVersion = CLOUD_VERSION_PARSED
+        if (currentVersion != null) {
+            if (!handleMigrations(currentVersion)) return
+        }
 
         nodeRepository.connect(this)
         @Suppress("TooGenericExceptionCaught")
@@ -372,6 +382,52 @@ class NodeService(
         check(
             thisNode.maxMemory <= Runtime.getRuntime().freeMemory()
         ) { "Not enough memory available! Please increase the max memory of this node!" }
+    }
+
+    /**
+     * Runs the migration runner. If the cluster schema version is ahead of this node,
+     * automatically downloads the correct version and shuts down for restart.
+     *
+     * @return `true` if startup can continue, `false` if the node is shutting down
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun handleMigrations(currentVersion: CloudVersion): Boolean {
+        val runner = MigrationRunner(databaseConnection)
+        val result = try {
+            runner.run(currentVersion)
+        } catch (e: Exception) {
+            LOGGER.severe("Migration failed! Node cannot start.", e)
+            shutdown()
+            return false
+        }
+
+        return when (result) {
+            is MigrationResult.Success -> true
+            is MigrationResult.UpgradeRequired -> {
+                autoUpgrade(result.targetVersion)
+                false
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun autoUpgrade(targetVersion: CloudVersion) {
+        LOGGER.info("Auto-upgrading to ${targetVersion.display}...")
+        try {
+            val releases = Updater.getReleasesByChannel(targetVersion.channel)
+            val release = releases.firstOrNull { it.version == targetVersion }
+            if (release == null) {
+                LOGGER.severe("Could not find release for version ${targetVersion.display}. Manual upgrade required.")
+                shutdown()
+                return
+            }
+            Updater.download(release)
+            Updater.switchVersion(release)
+            LOGGER.info("Auto-upgrade to ${targetVersion.display} complete. Shutting down for restart...")
+        } catch (e: Exception) {
+            LOGGER.severe("Auto-upgrade failed. Manual upgrade required.", e)
+        }
+        shutdown()
     }
 
     private fun registerPackets() {

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/NodeService.kt
@@ -34,6 +34,8 @@ import dev.redicloud.service.node.tasks.node.NodeChooseMasterTask
 import dev.redicloud.service.node.tasks.node.NodePingTask
 import dev.redicloud.service.node.tasks.node.NodeSelfSuspendTask
 import dev.redicloud.service.node.tasks.player.PlayerProxyConnectionStateTask
+import dev.redicloud.service.node.packets.upgrade.ClusterUpgradePacket
+import dev.redicloud.service.node.packets.upgrade.ClusterUpgradeResponsePacket
 import dev.redicloud.service.node.tasks.service.CloudInvalidServerUnregisterTask
 import dev.redicloud.updater.Updater
 import kotlinx.coroutines.runBlocking
@@ -373,7 +375,8 @@ class NodeService(
     }
 
     private fun registerPackets() {
-        // node-specific packets registered in BaseService
+        packetManager.registerPacket(ClusterUpgradePacket::class)
+        packetManager.registerPacket(ClusterUpgradeResponsePacket::class)
     }
 
     private suspend fun connectFileCluster() {
@@ -393,7 +396,7 @@ class NodeService(
             console.commandManager.registerCommand(command)
         }
         register(ExitCommand(this))
-        register(VersionCommand(console))
+        register(VersionCommand(console, serviceId, nodeRepository, packetManager))
         register(ClusterCommand(this))
         register(
             CloudServerVersionCommand(

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
@@ -1,10 +1,17 @@
 package dev.redicloud.service.node.commands
 
 import dev.redicloud.api.commands.*
+import dev.redicloud.api.packets.AbstractPacket
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.api.service.ServiceId
+import dev.redicloud.api.service.node.ICloudNode
+import dev.redicloud.api.service.node.ICloudNodeRepository
+import dev.redicloud.console.Console
 import dev.redicloud.console.animation.impl.line.AnimatedLineAnimation
 import dev.redicloud.console.commands.ConsoleActor
 import dev.redicloud.console.utils.toConsoleValue
-import dev.redicloud.service.node.console.NodeConsole
+import dev.redicloud.service.node.packets.upgrade.ClusterUpgradePacket
+import dev.redicloud.service.node.packets.upgrade.ClusterUpgradeResponsePacket
 import dev.redicloud.service.node.repository.node.LOGGER
 import dev.redicloud.updater.ReleaseInfo
 import dev.redicloud.updater.Updater
@@ -13,17 +20,25 @@ import dev.redicloud.updater.suggest.VersionSuggester
 import dev.redicloud.utils.*
 import dev.redicloud.utils.version.CloudVersion
 import dev.redicloud.utils.version.VersionChannel
+import kotlinx.coroutines.delay
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Command("version")
 @CommandAlias(["ver"])
 @CommandDescription("Displays the current version of the node service")
 class VersionCommand(
-    val console: NodeConsole
+    private val console: Console,
+    private val serviceId: ServiceId,
+    private val nodeRepository: ICloudNodeRepository,
+    private val packetManager: IPacketManager
 ) : ICommand {
 
     companion object {
         private const val ANIMATION_TICK_MS = 200L
         private const val UPGRADE_CONFIRM_TIMEOUT_MS = 30000
+        private val CLUSTER_UPGRADE_TIMEOUT = 120.seconds
     }
 
     @CommandSubPath("")
@@ -65,8 +80,8 @@ class VersionCommand(
     private val upgradeConfirms = mutableMapOf<String, Long>()
 
     @CommandSubPath("upgrade [channel] [version]")
-    @CommandDescription("Downloads and installs a version upgrade")
-    @Suppress("ReturnCount")
+    @CommandDescription("Downloads and installs a version upgrade on all cluster nodes")
+    @Suppress("ReturnCount", "LongMethod")
     suspend fun upgrade(
         actor: ConsoleActor,
         @CommandParameter("channel", false, ChannelSuggester::class) channelParam: String?,
@@ -113,49 +128,99 @@ class VersionCommand(
         }
         upgradeConfirms.remove(confirmKey)
 
-        // Download with animation
-        var animCanceled = false
-        var downloadError = false
-        var downloadDone = false
-        val animation = AnimatedLineAnimation(
-            console,
-            ANIMATION_TICK_MS
-        ) {
-            if (animCanceled) {
-                null
-            } else if (downloadDone) {
-                animCanceled = true
-                "Downloaded ${toConsoleValue(release.version.display)}§8: ${if (downloadError) "§4x" else "§2ok"}"
-            } else {
-                "Downloading ${toConsoleValue(release.version.display)}§8: %loading%"
+        // Collect cluster nodes
+        val allNodes = nodeRepository.getConnectedNodes()
+        val otherNodes = allNodes.filter { it.serviceId != serviceId }
+
+        // Build status tracker: nodeId -> status string
+        val nodeStatuses = ConcurrentHashMap<ServiceId, String>()
+        nodeStatuses[serviceId] = "§epending"
+        otherNodes.forEach { nodeStatuses[it.serviceId] = "§epending" }
+
+        // Pre-upgrade overview
+        actor.sendHeader("Cluster Upgrade")
+        actor.sendMessage("Upgrading cluster to %hc%${release.version.display}§8:")
+
+        // Start live-status animations (one per node)
+        val animationsDone = ConcurrentHashMap<ServiceId, Boolean>()
+
+        fun createNodeAnimation(node: ICloudNode, isThis: Boolean): AnimatedLineAnimation {
+            val label = if (isThis) "${node.name} §7(§athis§7)" else node.name
+            return AnimatedLineAnimation(console, ANIMATION_TICK_MS) {
+                val status = nodeStatuses[node.serviceId] ?: "§7unknown"
+                if (animationsDone[node.serviceId] == true) {
+                    null
+                } else if (status.contains("pending") || status.contains("downloading")) {
+                    "  §8- %hc%$label §8: $status %loading%"
+                } else {
+                    animationsDone[node.serviceId] = true
+                    "  §8- %hc%$label §8: $status"
+                }
             }
         }
-        console.startAnimation(animation)
 
+        // This node first
+        val thisNode = allNodes.first { it.serviceId == serviceId }
+        console.startAnimation(createNodeAnimation(thisNode, true))
+
+        // Other nodes
+        otherNodes.forEach { node ->
+            console.startAnimation(createNodeAnimation(node, false))
+        }
+
+        // Phase 1: Local upgrade
+        nodeStatuses[serviceId] = "§edownloading"
         @Suppress("TooGenericExceptionCaught")
         try {
             Updater.download(release)
-            downloadDone = true
-        } catch (e: Exception) {
-            downloadError = true
-            downloadDone = true
-            actor.sendMessage("§cFailed to download the version!")
-            LOGGER.severe("Failed to download the version", e)
-            return
-        }
-
-        // Switch version
-        @Suppress("TooGenericExceptionCaught")
-        try {
             Updater.switchVersion(release)
+            nodeStatuses[serviceId] = "§aupgraded"
         } catch (e: Exception) {
-            actor.sendMessage("§cFailed to install the version!")
-            LOGGER.severe("Failed to install the version", e)
+            nodeStatuses[serviceId] = "§cfailed §8(${e.message})"
+            LOGGER.severe("Failed to upgrade local node", e)
+            delay((ANIMATION_TICK_MS * 2).milliseconds)
+            actor.sendMessage("")
+            actor.sendMessage("§cLocal upgrade failed! Aborting cluster upgrade.")
+            actor.sendHeader("Cluster Upgrade")
             return
         }
 
-        actor.sendMessage("Upgraded to version %hc%${release.version.display}")
-        actor.sendMessage("§eChanges will be applied on next restart.")
+        // Phase 2: Remote upgrade
+        if (otherNodes.isNotEmpty()) {
+            otherNodes.forEach { nodeStatuses[it.serviceId] = "§edownloading" }
+
+            val receiverIds = otherNodes.map { it.serviceId }.toTypedArray()
+            val packet = ClusterUpgradePacket(
+                targetVersion = release.version.display,
+                targetChannel = channel.label
+            )
+
+            packetManager.publish(packet, *receiverIds)
+                .withTimeOut(CLUSTER_UPGRADE_TIMEOUT)
+                .waitForResponse(otherNodes.size) { response: AbstractPacket? ->
+                    if (response is ClusterUpgradeResponsePacket) {
+                        val senderId = response.sender ?: return@waitForResponse
+                        if (response.success) {
+                            nodeStatuses[senderId] = "§aupgraded"
+                        } else {
+                            nodeStatuses[senderId] = "§cfailed §8(${response.errorMessage ?: "unknown"})"
+                        }
+                    }
+                }
+        }
+
+        // Wait for animations to finish rendering
+        delay((ANIMATION_TICK_MS * 2).milliseconds)
+
+        // Summary
+        actor.sendMessage("")
+        val allSuccess = nodeStatuses.values.all { it.contains("upgraded") }
+        if (!allSuccess) {
+            actor.sendMessage("§cNot all nodes were upgraded successfully!")
+        }
+        actor.sendMessage("§eThe entire cluster must be shut down for the upgrade to take effect.")
+        actor.sendMessage("§eMigrations will run automatically on next startup.")
+        actor.sendHeader("Cluster Upgrade")
     }
 
     @CommandSubPath("channels")

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/commands/VersionCommand.kt
@@ -23,7 +23,7 @@ class VersionCommand(
 
     companion object {
         private const val ANIMATION_TICK_MS = 200L
-        private const val SWITCH_CONFIRM_TIMEOUT_MS = 30000
+        private const val UPGRADE_CONFIRM_TIMEOUT_MS = 30000
     }
 
     @CommandSubPath("")
@@ -55,73 +55,25 @@ class VersionCommand(
                 "An update is available: %hc%${release.version.display}"
             )
             actor.sendMessage(
-                "Download: %hc%version download ${release.channel.label} ${release.version.display}"
-            )
-            actor.sendMessage(
-                "Switch:   %hc%version switch ${release.channel.label} ${release.version.display}"
+                "Upgrade: %hc%version upgrade ${release.channel.label} ${release.version.display}"
             )
         } else {
             actor.sendMessage("You are running the latest version!")
         }
     }
 
-    @CommandSubPath("download [channel] [version]")
-    @CommandDescription("Downloads a version")
-    suspend fun download(
-        actor: ConsoleActor,
-        @CommandParameter("channel", false, ChannelSuggester::class) channelParam: String?,
-        @CommandParameter("version", false, VersionSuggester::class) versionParam: String?
-    ) {
-        val channel = channelParam?.let { VersionChannel.fromLabelOrNull(it) }
-            ?: CLOUD_VERSION_PARSED?.channel
-            ?: VersionChannel.STABLE
+    private val upgradeConfirms = mutableMapOf<String, Long>()
 
-        val release = resolveRelease(actor, channel, versionParam) ?: return
-
-        var canceled = false
-        var error = false
-        var downloaded = false
-        val animation = AnimatedLineAnimation(
-            console,
-            ANIMATION_TICK_MS
-        ) {
-            if (canceled) {
-                null
-            } else if (downloaded) {
-                canceled = true
-                "Downloaded ${toConsoleValue(release.version.display)}§8: ${if (error) "§4x" else "§2ok"}"
-            } else {
-                "Downloading ${toConsoleValue(release.version.display)}§8: %loading%"
-            }
-        }
-        console.startAnimation(animation)
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            Updater.download(release)
-            downloaded = true
-            actor.sendMessage(
-                "Switch with: %hc%version switch ${channel.label} ${release.version.display}"
-            )
-        } catch (e: Exception) {
-            error = true
-            downloaded = true
-            actor.sendMessage("§cFailed to download the version!")
-            LOGGER.severe("Failed to download the version", e)
-        }
-    }
-
-    private val switchConfirms = mutableMapOf<String, Long>()
-
-    @CommandSubPath("switch [channel] [version]")
-    @CommandDescription("Switch to a downloaded version")
+    @CommandSubPath("upgrade [channel] [version]")
+    @CommandDescription("Downloads and installs a version upgrade")
     @Suppress("ReturnCount")
-    suspend fun switch(
+    suspend fun upgrade(
         actor: ConsoleActor,
         @CommandParameter("channel", false, ChannelSuggester::class) channelParam: String?,
         @CommandParameter("version", false, VersionSuggester::class) versionParam: String?
     ) {
         if (Updater.updateToVersion != null) {
-            actor.sendMessage("§cAn update was already installed! Restart the node service to apply the changes!")
+            actor.sendMessage("§cAn upgrade is already pending! Restart the node service to apply the changes!")
             return
         }
 
@@ -137,42 +89,73 @@ class VersionCommand(
             return
         }
 
-        // Check if downloaded
-        val installed = Updater.localInstalledVersions()
-        val channelVersions = installed[channel] ?: emptyList()
-        if (release.version !in channelVersions) {
-            actor.sendMessage("§cVersion not downloaded!")
-            actor.sendMessage("§cDownload with: %hc%version download ${channel.label} ${release.version.display}")
-            return
-        }
-
         // Confirm channel change
         val confirmKey = release.version.display
         if (current != null && release.channel != current.channel &&
-            switchConfirms.getOrDefault(confirmKey, 0) + SWITCH_CONFIRM_TIMEOUT_MS < System.currentTimeMillis()
+            upgradeConfirms.getOrDefault(confirmKey, 0) + UPGRADE_CONFIRM_TIMEOUT_MS < System.currentTimeMillis()
         ) {
             actor.sendMessage("§cYou are switching to a different channel (${channel.label})!")
             actor.sendMessage("§cThis can cause issues. Backup your data first!")
             actor.sendMessage("§cType the command again to confirm!")
-            switchConfirms[confirmKey] = System.currentTimeMillis()
+            upgradeConfirms[confirmKey] = System.currentTimeMillis()
             return
         }
 
         // Confirm downgrade
         if (current != null && release.version < current &&
-            switchConfirms.getOrDefault(confirmKey, 0) + SWITCH_CONFIRM_TIMEOUT_MS < System.currentTimeMillis()
+            upgradeConfirms.getOrDefault(confirmKey, 0) + UPGRADE_CONFIRM_TIMEOUT_MS < System.currentTimeMillis()
         ) {
             actor.sendMessage("§cYou are downgrading to ${release.version.display}!")
             actor.sendMessage("§cThis can cause issues and data loss!")
             actor.sendMessage("§cType the command again to confirm!")
-            switchConfirms[confirmKey] = System.currentTimeMillis()
+            upgradeConfirms[confirmKey] = System.currentTimeMillis()
+            return
+        }
+        upgradeConfirms.remove(confirmKey)
+
+        // Download with animation
+        var animCanceled = false
+        var downloadError = false
+        var downloadDone = false
+        val animation = AnimatedLineAnimation(
+            console,
+            ANIMATION_TICK_MS
+        ) {
+            if (animCanceled) {
+                null
+            } else if (downloadDone) {
+                animCanceled = true
+                "Downloaded ${toConsoleValue(release.version.display)}§8: ${if (downloadError) "§4x" else "§2ok"}"
+            } else {
+                "Downloading ${toConsoleValue(release.version.display)}§8: %loading%"
+            }
+        }
+        console.startAnimation(animation)
+
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            Updater.download(release)
+            downloadDone = true
+        } catch (e: Exception) {
+            downloadError = true
+            downloadDone = true
+            actor.sendMessage("§cFailed to download the version!")
+            LOGGER.severe("Failed to download the version", e)
             return
         }
 
-        switchConfirms.remove(confirmKey)
-        Updater.switchVersion(release)
-        actor.sendMessage("Activated version: %hc%${release.version.display}")
-        actor.sendMessage("§cRestart the node service to apply the changes!")
+        // Switch version
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            Updater.switchVersion(release)
+        } catch (e: Exception) {
+            actor.sendMessage("§cFailed to install the version!")
+            LOGGER.severe("Failed to install the version", e)
+            return
+        }
+
+        actor.sendMessage("Upgraded to version %hc%${release.version.display}")
+        actor.sendMessage("§eChanges will be applied on next restart.")
     }
 
     @CommandSubPath("channels")
@@ -230,7 +213,7 @@ class VersionCommand(
         val installedVersions = Updater.localInstalledVersions()
         if (installedVersions.isEmpty()) {
             actor.sendMessage("No versions downloaded!")
-            actor.sendMessage("Download with: ${toConsoleValue("version download <channel> [version]")}")
+            actor.sendMessage("Upgrade with: ${toConsoleValue("version upgrade [channel] [version]")}")
             return
         }
         val current = CLOUD_VERSION_PARSED

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/packets/upgrade/ClusterUpgradePacket.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/packets/upgrade/ClusterUpgradePacket.kt
@@ -1,0 +1,61 @@
+package dev.redicloud.service.node.packets.upgrade
+
+import dev.redicloud.api.packets.AbstractPacket
+import dev.redicloud.api.packets.IPacketManager
+import dev.redicloud.logging.LogManager
+import dev.redicloud.updater.Updater
+import dev.redicloud.utils.version.CloudVersion
+import dev.redicloud.utils.version.VersionChannel
+
+class ClusterUpgradePacket(
+    val targetVersion: String,
+    val targetChannel: String
+) : AbstractPacket() {
+
+    companion object {
+        private val LOGGER = LogManager.logger(ClusterUpgradePacket::class)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun received(manager: IPacketManager) {
+        super.received(manager)
+
+        val channel = VersionChannel.fromLabelOrNull(targetChannel)
+        if (channel == null) {
+            respond(ClusterUpgradeResponsePacket(false, "Unknown channel: $targetChannel"))
+            return
+        }
+
+        val version = CloudVersion.parseOrNull(targetVersion)
+        if (version == null) {
+            respond(ClusterUpgradeResponsePacket(false, "Invalid version: $targetVersion"))
+            return
+        }
+
+        try {
+            LOGGER.info("Received cluster upgrade request to $targetVersion ($targetChannel)")
+
+            // Find the release
+            val releases = Updater.getReleasesByChannel(channel)
+            val release = releases.firstOrNull { it.version == version }
+            if (release == null) {
+                respond(ClusterUpgradeResponsePacket(false, "Release not found: $targetVersion"))
+                return
+            }
+
+            // Download + verify
+            LOGGER.info("Downloading version $targetVersion...")
+            Updater.download(release)
+
+            // Switch version
+            LOGGER.info("Installing version $targetVersion...")
+            Updater.switchVersion(release)
+
+            LOGGER.info("Upgrade to $targetVersion complete. Changes will be applied on next restart.")
+            respond(ClusterUpgradeResponsePacket(true))
+        } catch (e: Exception) {
+            LOGGER.severe("Failed to upgrade to $targetVersion", e)
+            respond(ClusterUpgradeResponsePacket(false, e.message ?: "Unknown error"))
+        }
+    }
+}

--- a/services/node-service/src/main/kotlin/dev/redicloud/service/node/packets/upgrade/ClusterUpgradeResponsePacket.kt
+++ b/services/node-service/src/main/kotlin/dev/redicloud/service/node/packets/upgrade/ClusterUpgradeResponsePacket.kt
@@ -1,0 +1,8 @@
+package dev.redicloud.service.node.packets.upgrade
+
+import dev.redicloud.api.packets.AbstractPacket
+
+class ClusterUpgradeResponsePacket(
+    val success: Boolean,
+    val errorMessage: String? = null
+) : AbstractPacket()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -88,6 +88,9 @@ findProject(":connectors:minestom-connector")?.name = "minestom-connector"
 include("updater")
 findProject(":updater")?.name = "updater"
 
+include("migrations")
+findProject(":migrations")?.name = "migrations"
+
 include("apis:connector-api")
 findProject(":apis:connector-api")?.name = "connector-api"
 

--- a/updater/src/main/kotlin/dev/redicloud/updater/Updater.kt
+++ b/updater/src/main/kotlin/dev/redicloud/updater/Updater.kt
@@ -40,8 +40,7 @@ object Updater {
         val (available, release) = updateAvailable()
         if (available && release != null) {
             LogManager.rootLogger().info("Update available: ${release.version.display}")
-            LogManager.rootLogger().info("  Download:  version download ${release.version.display}")
-            LogManager.rootLogger().info("  Switch:    version switch ${release.version.display}")
+            LogManager.rootLogger().info("  Upgrade:   version upgrade ${release.channel.label} ${release.version.display}")
         } else {
             LogManager.rootLogger().info("You are running the latest version!")
         }
@@ -217,7 +216,7 @@ object Updater {
         val versionsDir = File("versions")
         val zipFile = File(versionsDir, "redicloud-${release.version.display}.zip")
         check(zipFile.exists()) {
-            "Version ${release.version.display} is not downloaded. Run: version download ${release.version.display}"
+            "Version ${release.version.display} is not downloaded. Run: version upgrade ${release.version.display}"
         }
 
         unzipFile(zipFile.absolutePath, File(".").absolutePath)


### PR DESCRIPTION
Replaces the two-step version download + version switch workflow with a single version upgrade command and introduces a database/file migration framework for safe cluster-wide version transitions.

## Changes
### Upgrade Command
- Removed version download and version switch subcommands
- Added version upgrade [channel] [version] — downloads, verifies, and installs in one step
- Safety confirmations (channel change, downgrade warnings) retained
- All references in checkupdate, downloaded, and Updater.kt startup messages updated

### Cluster-Wide Upgrade
- version upgrade automatically upgrades all connected cluster nodes via ClusterUpgradePacket
- Each remote node downloads from GitHub independently and reports success/failure
- Live status overview with per-node animations (pending → downloading → upgraded/failed)
- Pre-upgrade node list and post-upgrade summary with cluster shutdown reminder
- 120s timeout for remote node responses

### Migration Framework (migrations/ module)
- New Gradle subproject with Migration interface (version, type, up()/down())
- Two migration types:
  - DATABASE — shared Redis changes, executed once per cluster with distributed lock (cloud:migration-lock)
  - LOCAL — file/folder changes, executed on every node independently
- MigrationRegistry for explicit registration with version-range queries (supports upgrade + downgrade)
- MigrationRunner handles the full startup flow:
  - Reads cloud:schema-version from Redis, compares with JAR version
  - Acquires distributed lock for DB migrations (5min timeout)
  - Wait-state with 2s polling when another node holds the lock (10min timeout)
  - Tracks local migrations via .local-schema-version file

### Auto-Upgrade on Version Mismatch
- On startup, if cloud:schema-version is ahead of the node's JAR version, the node automatically downloads the correct release, installs it, and shuts down for restart
- Migrations run before the node registers as connected — no inconsistent cluster state

### Startup Flow (NodeService)
Updater.check()          → cleanup old JARs, log available updates
MigrationRunner.run()    → returns UpgradeRequired or Success
  ├─ UpgradeRequired     → auto-download + switch + shutdown
  └─ Success             → DB migrations (with lock) + local migrations
nodeRepository.connect() → node registers as connected